### PR TITLE
Retry feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,104 @@
 ![GHCR Image Version (latest)](https://ghcr-badge.egpl.dev/ankitmehtame/http-forwarder-app/latest_tag?color=%2344cc11&ignore=&label=version&trim=)
 
 # http-forwarder
-Forwards http traffic onto private network
 
-### To build docker image
-From the root directory
+http-forwarder is a small HTTP proxy/forwarder intended to accept incoming HTTP requests and forward them into a private/internal network or target service. It is packaged to run easily as a Docker container and is useful for simple tunneling or edge forwarding scenarios.
+
+## What this project does
+- Listens for inbound HTTP requests on a configurable port.
+- Forwards those requests to an internal or private target URL (configurable).
+- Preserves request method, path, headers and body by default, with options to add or override headers.
+- Exposes a simple health endpoint for liveness checks.
+- Runs as a standalone binary or inside a container.
+
+## How it works (high level)
+- The forwarder accepts an incoming HTTP connection on its listen port.
+- It maps the request to a configured backend (single target or simple routing) and performs an HTTP request to that backend.
+- Response from the backend is proxied back to the original client, including status, headers and body.
+- Basic logging and timeout handling are applied to avoid hanging requests.
+
+## Build (Docker)
+From the repository root:
 ```
 docker build -t http-forwarder-app:latest -t http-forwarder-app:0.n .
 ```
 
-### To run interactively
-From the root directory
+## Run (Docker, interactive)
 ```
 docker run -it --rm -p 5000:8080 --name http-forwarder-app http-forwarder-app
 ```
+
+## Common configuration
+- `LISTEN_PORT` (default: 8080) — port the forwarder listens on inside the container.
+- `TARGET_URL` — the backend URL to forward requests to (e.g. `http://10.0.0.5:80` or `http://service.local`).
+- `TIMEOUT` — request timeout when calling the backend.
+- `LOG_LEVEL` — logging verbosity (`info`, `debug`, `error`).
+- `ADDITIONAL_HEADERS` — optional headers to inject when forwarding (format depends on implementation).
+
+## Docker volumes configuration
+```yaml
+    - './httpforwarder/conf:/app/conf:ro'
+    - './httpforwarder/storage:/app/storage:rw'
+    - './logs/httpforwarder:/app/logs'
+    - './httpforwarder/.secrets:/app/.secrets:ro'
+```
+conf folder is for configuration - forwarding rules live here
+storage folder is for temporary storage - up to 24 hours, after which any failed requests will be deleted
+
+## Usage examples
+- Forward a request to the configured target:
+  ```
+  curl -i http://localhost:5000/forward/event-name
+  ```
+
+- Check health:
+  ```
+  curl -i http://localhost:5000/health
+  ```
+
+## Sample rules config
+```json
+[
+    {
+        "method": "GET",
+        "event": "TEST",
+        "targetUrl": "https://httpbin.org/get?name=test&value=123",
+        "tags": [
+            "local",
+            "home",
+            "cloud"
+        ]
+    },
+    {
+        "method": "POST",
+        "event": "TEST",
+        "targetUrl": "https://httpbin.org/post",
+        "content": "{\"name\": \"Test Person\", \"age\": 99}",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "hasContent": false,
+        "isRetryable": false,
+        "tags": [
+            "local",
+            "home",
+            "cloud"
+        ]
+    }
+```
+Credit to https://httpbin.org for offering an internet based service to test REST functions.
+
+## Notes and troubleshooting
+- Ensure the container/network can reach the private target (firewalls, VPNs, and Docker network settings can block access).
+- Use logs to diagnose header transformations or backend errors.
+- If you need multiple backend targets or complex routing, consider using a dedicated reverse proxy (nginx, Traefik) or an API gateway.
+
+## How I use this application
+I have multiple instances running. Few on my local homelab (for redundancy), another on Google Cloud as a Cloud Run function. This is so that some of my mobile devices can forward calls to the cloud first, which will simply queue up the requests for an instance to prcoess. Rules can be tagged as running on home or cloud, so only that type of instance will process the request.
+For example, I want requests to my Home Assistant to be processed by my local homelab instance, whereas any requests to Telegram (one of my preferred notification service) can be processed in the cloud as well as at home.
+
+## Contributing
+- Fixes, improvements and documentation updates are welcome via pull requests.
+
+## License
+- See repository for license information.

--- a/http-forwarder-acceptance-tests/CustomWebApplicationFactory.cs
+++ b/http-forwarder-acceptance-tests/CustomWebApplicationFactory.cs
@@ -1,4 +1,5 @@
 using http_forwarder_app.Cloud;
+using http_forwarder_app.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -25,6 +26,7 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
             s.AddTransient<HttpMessageHandlerBuilder>(sp => new TestServerHttpMessageHandlerBuilder(Server));
             s.Remove(s.Single(x => x.ImplementationType == typeof(PublisherClientFactory)));
             s.AddSingleton<IPublisherClientFactory, StubPublisherClientFactory>();
+            s.Remove(s.Single(x => x.ImplementationType == typeof(RetryBackgroundService)));
         });
     }
 }

--- a/http-forwarder-acceptance-tests/ForwarderAcceptanceTests.cs
+++ b/http-forwarder-acceptance-tests/ForwarderAcceptanceTests.cs
@@ -71,6 +71,6 @@ public class ForwarderAcceptanceTests(CustomWebApplicationFactory<Program> facto
 
         response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
         var responseText = await response.Content.ReadAsStringAsync();
-        responseText.ShouldBe("Request accepted for retry");
+        responseText.ShouldStartWith("Request accepted for retry - ");
     }
 }

--- a/http-forwarder-acceptance-tests/ForwarderAcceptanceTests.cs
+++ b/http-forwarder-acceptance-tests/ForwarderAcceptanceTests.cs
@@ -5,6 +5,7 @@ using http_forwarder_app.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
+using System.Net;
 
 namespace http_forwarder_acceptance_tests;
 
@@ -59,5 +60,17 @@ public class ForwarderAcceptanceTests(CustomWebApplicationFactory<Program> facto
         var expectedMessage = new ForwardingRequest(Method: "POST", Event: "cloud-test", Content: """{}""");
         var expectedMessageJson = JsonUtils.Serialize(expectedMessage, false);
         messageData.ShouldBe(expectedMessageJson);
+    }
+
+    [Fact]
+    public async Task PostFailShouldReturnAcceptedForRetry()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/forward/ping-fail", new StringContent("""{}"""));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        var responseText = await response.Content.ReadAsStringAsync();
+        responseText.ShouldBe("Request accepted for retry");
     }
 }

--- a/http-forwarder-app/Controllers/ForwardingController.cs
+++ b/http-forwarder-app/Controllers/ForwardingController.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using http_forwarder_app.Core;
@@ -7,6 +8,7 @@ using http_forwarder_app.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using OneOf;
 
@@ -17,12 +19,20 @@ namespace http_forwarder_app.Controllers
     [Route("api/[controller]")]
     [Route("forward")]
     [Route("api/forward")]
-    public class ForwardingController(ForwardingService forwardingService, RemoteRulePublishingService remoteRulePublishingService, IConfiguration configuration, ILogger<ForwardingController> logger) : ControllerBase
+    public class ForwardingController(
+        IForwardingService forwardingService,
+        RemoteRulePublishingService remoteRulePublishingService,
+        IFailedRequestStorage failedRequestStorage,
+        IConfiguration configuration,
+        ISystemClock clock,
+        ILogger<ForwardingController> logger) : ControllerBase
     {
-        private readonly ForwardingService _forwardingService = forwardingService;
+        private readonly IForwardingService _forwardingService = forwardingService;
+        private readonly IFailedRequestStorage _failedRequestStorage = failedRequestStorage;
         private readonly IConfiguration _configuration = configuration;
         private readonly ILogger<ForwardingController> _logger = logger;
         private readonly RemoteRulePublishingService _remoteRulePublishingService = remoteRulePublishingService;
+        private readonly ISystemClock _clock = clock;
 
         [HttpGet]
         public object Get()
@@ -37,7 +47,7 @@ namespace http_forwarder_app.Controllers
             string method = Request.Method;
             var result = await _forwardingService.ProcessGetEvent(eventName, GetHostUrl(Request));
             await result.Match(
-                async callResp => await HttpContext.CopyHttpResponse(callResp),
+                async ruleResult => await HttpContext.CopyHttpResponse(ruleResult.Response),
                 async noRuleFound =>
                 {
                     Response.StatusCode = StatusCodes.Status404NotFound;
@@ -66,7 +76,18 @@ namespace http_forwarder_app.Controllers
             var result = await _forwardingService.ProcessPostEvent(eventName, GetHostUrl(Request), requestContent);
 
             await result.Match(
-                async callResp => await HttpContext.CopyHttpResponse(callResp),
+                async ruleResult =>
+                {
+                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    {
+                        if (ruleResult.Rule.IsRetryable)
+                        {
+                            await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
+                            return;
+                        }
+                    }
+                    await HttpContext.CopyHttpResponse(ruleResult.Response);
+                },
                 async noRuleFound =>
                 {
                     Response.StatusCode = StatusCodes.Status404NotFound;
@@ -98,7 +119,18 @@ namespace http_forwarder_app.Controllers
             var result = await _forwardingService.ProcessPutEvent(eventName, GetHostUrl(Request), requestContent);
 
             await result.Match(
-                async callResp => await HttpContext.CopyHttpResponse(callResp),
+                async ruleResult =>
+                {
+                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    {
+                        if (ruleResult.Rule.IsRetryable)
+                        {
+                            await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
+                            return;
+                        }
+                    }
+                    await HttpContext.CopyHttpResponse(ruleResult.Response);
+                },
                 async noRuleFound =>
                 {
                     Response.StatusCode = StatusCodes.Status404NotFound;
@@ -124,7 +156,18 @@ namespace http_forwarder_app.Controllers
 
             var result = await _forwardingService.ProcessDeleteEvent(eventName, GetHostUrl(Request));
             await result.Match(
-                async callResp => await HttpContext.CopyHttpResponse(callResp),
+                async ruleResult =>
+                {
+                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    {
+                        if (ruleResult.Rule.IsRetryable)
+                        {
+                            await HandleFailedRequest(ruleResult.Rule, null, await ruleResult.Response.Content.ReadAsStringAsync());
+                            return;
+                        }
+                    }
+                    await HttpContext.CopyHttpResponse(ruleResult.Response);
+                },
                 async noRuleFound =>
                 {
                     Response.StatusCode = StatusCodes.Status404NotFound;
@@ -162,6 +205,27 @@ namespace http_forwarder_app.Controllers
                 }
             );
         }
+
+        private async Task HandleFailedRequest(ForwardingRule rule, string? content, string error)
+        {
+            var creationTime = _clock.UtcNow;
+            var failedRequest = new FailedRequest(
+                Id: Guid.NewGuid(),
+                Rule: rule with { Content = content },
+                FirstAttempt: creationTime,
+                LastAttempt: creationTime,
+                AttemptCount: 1,
+                NextAttempt: creationTime.AddSeconds(30),
+                LastError: error
+            );
+
+            _failedRequestStorage.Store(failedRequest);
+            Response.StatusCode = StatusCodes.Status202Accepted;
+            await Response.WriteAsync("Request accepted for retry");
+        }
+
+        private static bool IsServerError(System.Net.HttpStatusCode statusCode) =>
+            (int)statusCode >= 500 && (int)statusCode <= 599;
 
         private static async Task<string?> GetBodyFromHttpRequest(HttpRequest request)
         {

--- a/http-forwarder-app/Controllers/ForwardingController.cs
+++ b/http-forwarder-app/Controllers/ForwardingController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using http_forwarder_app.Core;
@@ -77,13 +78,10 @@ namespace http_forwarder_app.Controllers
             await result.Match(
                 async ruleResult =>
                 {
-                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    if (ruleResult.Response.IsServerError() && ruleResult.Rule.IsRetryable)
                     {
-                        if (ruleResult.Rule.IsRetryable)
-                        {
-                            await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
-                            return;
-                        }
+                        await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
+                        return;
                     }
                     await HttpContext.CopyHttpResponse(ruleResult.Response);
                 },
@@ -118,13 +116,10 @@ namespace http_forwarder_app.Controllers
             await result.Match(
                 async ruleResult =>
                 {
-                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    if (ruleResult.Response.IsServerError() && ruleResult.Rule.IsRetryable)
                     {
-                        if (ruleResult.Rule.IsRetryable)
-                        {
-                            await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
-                            return;
-                        }
+                        await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
+                        return;
                     }
                     await HttpContext.CopyHttpResponse(ruleResult.Response);
                 },
@@ -158,13 +153,10 @@ namespace http_forwarder_app.Controllers
             await result.Match(
                 async ruleResult =>
                 {
-                    if (!ruleResult.Response.IsSuccessStatusCode && IsServerError(ruleResult.Response.StatusCode))
+                    if (ruleResult.Response.IsServerError() && ruleResult.Rule.IsRetryable)
                     {
-                        if (ruleResult.Rule.IsRetryable)
-                        {
-                            await HandleFailedRequest(ruleResult.Rule, null, await ruleResult.Response.Content.ReadAsStringAsync());
-                            return;
-                        }
+                        await HandleFailedRequest(ruleResult.Rule, requestContent, await ruleResult.Response.Content.ReadAsStringAsync());
+                        return;
                     }
                     await HttpContext.CopyHttpResponse(ruleResult.Response);
                 },
@@ -216,17 +208,18 @@ namespace http_forwarder_app.Controllers
                 FirstAttempt: creationTime,
                 LastAttempt: creationTime,
                 AttemptCount: 1,
-                NextAttempt: creationTime.AddSeconds(30),
+                NextAttempt: creationTime.Add(RetryBackgroundService.RetryIntervalMin),
                 LastError: error
             );
 
+            _logger.LogInformation("Adding request {requestId} with event {eventName} to storage to be executed at {attemptTime}",
+                failedRequest.Id,
+                failedRequest.Rule.Event,
+                failedRequest.NextAttempt);
             _failedRequestStorage.Store(failedRequest);
             Response.StatusCode = StatusCodes.Status202Accepted;
-            await Response.WriteAsync("Request accepted for retry");
+            await Response.WriteAsync(string.Format(CultureInfo.InvariantCulture, "Request accepted for retry - {0}", failedRequest.Id));
         }
-
-        private static bool IsServerError(System.Net.HttpStatusCode statusCode) =>
-            (int)statusCode >= 500 && (int)statusCode <= 599;
 
         private static string GetHostUrl(HttpRequest request)
         {

--- a/http-forwarder-app/Controllers/ForwardingController.cs
+++ b/http-forwarder-app/Controllers/ForwardingController.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.IO;
-using System.Net.Mime;
 using System.Threading.Tasks;
 using http_forwarder_app.Core;
 using http_forwarder_app.Models;
 using http_forwarder_app.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
@@ -62,17 +62,16 @@ namespace http_forwarder_app.Controllers
         }
 
         /// <summary>
-        /// Post method can take body also
+        /// Forward a POST request to configured endpoint
         /// </summary>
-        [HttpPost]
-        [Consumes(MediaTypeNames.Text.Plain, MediaTypeNames.Application.Json, MediaTypeNames.Image.Jpeg, MediaTypeNames.Application.Octet, MediaTypeNames.Application.Zip, MediaTypeNames.Image.Tiff, MediaTypeNames.Text.Html, MediaTypeNames.Text.RichText, MediaTypeNames.Text.Xml)]
-        [Route("{eventName}")]
-        public async Task Post(string eventName)
+        /// <param name="eventName">Event name to match forwarding rule</param>
+        /// <param name="body">Request body (shown in Swagger). Raw body will still be used for processing.</param>
+        [HttpPost("{eventName}")]
+        public async Task Post(string eventName, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] object? body = null)
         {
             string method = Request.Method;
-
-            var requestContent = await GetBodyFromHttpRequest(Request) ?? string.Empty;
-
+            Request.EnableBuffering();
+            var requestContent = await ReadRequestBody(Request);
             var result = await _forwardingService.ProcessPostEvent(eventName, GetHostUrl(Request), requestContent);
 
             await result.Match(
@@ -106,16 +105,14 @@ namespace http_forwarder_app.Controllers
         }
 
         /// <summary>
-        /// Put method can take body also
+        /// Forward a PUT request to configured endpoint
         /// </summary>
-        [HttpPut]
-        [Route("{eventName}")]
-        public async Task Put(string eventName)
+        [HttpPut("{eventName}")]
+        public async Task Put(string eventName, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] object? body = null)
         {
             string method = Request.Method;
-
-            var requestContent = await GetBodyFromHttpRequest(Request) ?? string.Empty;
-
+            Request.EnableBuffering();
+            var requestContent = await ReadRequestBody(Request);
             var result = await _forwardingService.ProcessPutEvent(eventName, GetHostUrl(Request), requestContent);
 
             await result.Match(
@@ -148,12 +145,15 @@ namespace http_forwarder_app.Controllers
             );
         }
 
-        [HttpDelete]
-        [Route("{eventName}")]
-        public async Task Delete(string eventName)
+        /// <summary>
+        /// Forward a DELETE request to configured endpoint
+        /// </summary>
+        [HttpDelete("{eventName}")]
+        public async Task Delete(string eventName, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] object? body = null)
         {
             string method = Request.Method;
-
+            Request.EnableBuffering();
+            var requestContent = await ReadRequestBody(Request);
             var result = await _forwardingService.ProcessDeleteEvent(eventName, GetHostUrl(Request));
             await result.Match(
                 async ruleResult =>
@@ -212,6 +212,7 @@ namespace http_forwarder_app.Controllers
             var failedRequest = new FailedRequest(
                 Id: Guid.NewGuid(),
                 Rule: rule with { Content = content },
+                RequestHostUrl: GetHostUrl(Request),
                 FirstAttempt: creationTime,
                 LastAttempt: creationTime,
                 AttemptCount: 1,
@@ -227,20 +228,19 @@ namespace http_forwarder_app.Controllers
         private static bool IsServerError(System.Net.HttpStatusCode statusCode) =>
             (int)statusCode >= 500 && (int)statusCode <= 599;
 
-        private static async Task<string?> GetBodyFromHttpRequest(HttpRequest request)
-        {
-            var bodyStream = request?.Body;
-            if (bodyStream != null)
-            {
-                TextReader tr = new StreamReader(bodyStream);
-                return await tr.ReadToEndAsync();
-            }
-            return null;
-        }
-
         private static string GetHostUrl(HttpRequest request)
         {
             return $"{request.Scheme}://{request.Host}";
+        }
+
+        // helper to read the raw body; leaves stream position reset for other readers
+        private static async Task<string> ReadRequestBody(HttpRequest request)
+        {
+            request.Body.Position = 0;
+            using var reader = new StreamReader(request.Body, leaveOpen: true);
+            var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+            request.Body.Position = 0;
+            return content;
         }
     }
 }

--- a/http-forwarder-app/Controllers/PingController.cs
+++ b/http-forwarder-app/Controllers/PingController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace http_forwarder_app.Controllers;
@@ -14,10 +15,14 @@ public class PingController : ControllerBase
     }
 
     [HttpPost]
-    public Task<Pong> PongAsync(Ping? ping)
+    public Task<IActionResult> PongAsync(Ping? ping)
     {
-        if (ping == null) return Task.FromResult(new Pong("Pong"));
-        return Task.FromResult(new Pong(ping.Message));
+        if (ping == null) return Task.FromResult<IActionResult>(Ok(new Pong("Pong")));
+        if (string.Equals(ping.Message, "fail", System.StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult<IActionResult>(StatusCode(StatusCodes.Status503ServiceUnavailable, "Service temporarily unavailable"));
+        }
+        return Task.FromResult<IActionResult>(Ok(new Pong(ping.Message)));
     }
 
     public record class Pong(string Message);

--- a/http-forwarder-app/Core/PathUtils.cs
+++ b/http-forwarder-app/Core/PathUtils.cs
@@ -16,10 +16,28 @@ namespace http_forwarder_app.Core
             return realPath;
         }
 
+        public static string GetStorageDirPath(this IConfiguration configuration)
+        {
+            var appRoot = configuration.GetAppRoot();
+            var pathsForStorage = new[] { configuration["RetryStorage:DirPath"], Path.Combine(appRoot, $"storage"), Path.Combine(appRoot, @".\..\storage") }
+                .Where(p => !string.IsNullOrEmpty(p))
+                .ToArray()!;
+            var realPath = pathsForStorage.FirstOrDefault(Directory.Exists) ?? pathsForStorage.First();
+            return realPath;
+        }
+
         public static string GetConfFilePath(this IConfiguration configuration, string fileName)
         {
             var pathForConf = configuration.GetConfDirPath();
             var possiblePath = Path.Combine(pathForConf, fileName);
+            var filePath = GetFilePath(possiblePath) ?? possiblePath;
+            return filePath;
+        }
+
+        public static string GetStorageFilePath(this IConfiguration configuration)
+        {
+            var pathForConf = configuration.GetStorageDirPath();
+            var possiblePath = Path.Combine(pathForConf, "storage.json");
             var filePath = GetFilePath(possiblePath) ?? possiblePath;
             return filePath;
         }

--- a/http-forwarder-app/Core/PathUtils.cs
+++ b/http-forwarder-app/Core/PathUtils.cs
@@ -16,10 +16,10 @@ namespace http_forwarder_app.Core
             return realPath;
         }
 
-        public static string GetStorageDirPath(this IConfiguration configuration)
+        public static string GetValidStorageDirPath(this IConfiguration configuration)
         {
             var appRoot = configuration.GetAppRoot();
-            var pathsForStorage = new[] { configuration["RetryStorage:DirPath"], Path.Combine(appRoot, $"storage"), Path.Combine(appRoot, @".\..\storage") }
+            var pathsForStorage = new[] { configuration.GetConfiguredStoragePath(), Path.Combine(appRoot, $"storage"), Path.Combine(appRoot, @".\..\storage") }
                 .Where(p => !string.IsNullOrEmpty(p))
                 .ToArray()!;
             var realPath = pathsForStorage.FirstOrDefault(Directory.Exists) ?? pathsForStorage.First();
@@ -29,16 +29,16 @@ namespace http_forwarder_app.Core
         public static string GetConfFilePath(this IConfiguration configuration, string fileName)
         {
             var pathForConf = configuration.GetConfDirPath();
-            var possiblePath = Path.Combine(pathForConf, fileName);
-            var filePath = GetFilePath(possiblePath) ?? possiblePath;
+            var filePath = GetFilePath(Path.Combine(pathForConf, fileName));
+            filePath ??= Path.Combine(pathForConf, fileName);
             return filePath;
         }
 
         public static string GetStorageFilePath(this IConfiguration configuration)
         {
-            var pathForConf = configuration.GetStorageDirPath();
-            var possiblePath = Path.Combine(pathForConf, "storage.json");
-            var filePath = GetFilePath(possiblePath) ?? possiblePath;
+            var pathForConf = configuration.GetValidStorageDirPath();
+            var filePath = GetFilePath(Path.Combine(pathForConf, "storage.json"));
+            filePath ??= Path.Combine(pathForConf, "storage.json");
             return filePath;
         }
 

--- a/http-forwarder-app/Core/RetryExtensions.cs
+++ b/http-forwarder-app/Core/RetryExtensions.cs
@@ -4,9 +4,9 @@ namespace http_forwarder_app.Extensions;
 
 public static class RetryExtensions
 {
-    public static double CalculateExponentialDelay(this int attemptCount, int baseDelay, int maxDelay)
+    public static TimeSpan CalculateExponentialDelay(this int attemptCount, TimeSpan baseDelay, TimeSpan maxDelay)
     {
-        var delay = Math.Min(baseDelay * Math.Pow(2, attemptCount - 1), maxDelay);
-        return delay;
+        var delay = Math.Min(baseDelay.TotalSeconds * Math.Pow(2, attemptCount - 1), maxDelay.TotalSeconds);
+        return TimeSpan.FromSeconds(delay);
     }
 }

--- a/http-forwarder-app/Core/RetryExtensions.cs
+++ b/http-forwarder-app/Core/RetryExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace http_forwarder_app.Extensions;
+
+public static class RetryExtensions
+{
+    public static double CalculateExponentialDelay(this int attemptCount, int baseDelay, int maxDelay)
+    {
+        var delay = Math.Min(baseDelay * Math.Pow(2, attemptCount - 1), maxDelay);
+        return delay;
+    }
+}

--- a/http-forwarder-app/Formatters/RawRequestBodyFormatter.cs
+++ b/http-forwarder-app/Formatters/RawRequestBodyFormatter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+using http_forwarder_app.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace http_forwarder_app.Formatters;
+
+public class RawRequestBodyFormatter : InputFormatter
+{
+    public RawRequestBodyFormatter()
+    {
+        SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
+        SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/plain"));
+        SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/octet-stream"));
+    }
+
+    public override bool CanRead(InputFormatterContext context)
+    {
+        // Accept any request so model binding picks this up for [FromBody] object/string parameters
+        // and so we can attempt JSON deserialization for typed models even when Content-Type is missing.
+        return true;
+    }
+
+    public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+    {
+        var request = context.HttpContext.Request;
+        request.EnableBuffering();
+
+        using var reader = new StreamReader(request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+        // Reset position so action or other components can read the body again
+        request.Body.Position = 0;
+
+        // If the target model type is string or object, return the raw string
+        if (context.ModelType == typeof(string) || context.ModelType == typeof(object))
+        {
+            return await InputFormatterResult.SuccessAsync(content);
+        }
+
+        // Try to deserialize JSON into the target model type even if Content-Type was not set.
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                var model = JsonUtils.Deserialize(content, context.ModelType);
+                if (model != null)
+                {
+                    return await InputFormatterResult.SuccessAsync(model);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // fall-through to NoValue so other formatters can try or framework can return a 400 as appropriate
+        }
+
+        return await InputFormatterResult.NoValueAsync();
+    }
+}

--- a/http-forwarder-app/Program.cs
+++ b/http-forwarder-app/Program.cs
@@ -10,6 +10,7 @@ using http_forwarder_app.Models.Services;
 using http_forwarder_app.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Internal;
@@ -22,7 +23,12 @@ AddEnvironmentVariables(newArgs, new Dictionary<string, string> { { "VERSION", V
 var builder = WebApplication.CreateBuilder(newArgs.ToArray());
 builder.Logging.AddConsole();
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+{
+    // Insert raw body formatter at the beginning so [FromBody] object parameters bind even when Content-Type
+    // is missing/unexpected. This keeps backward compatibility for non-JSON clients.
+    options.InputFormatters.Insert(0, new http_forwarder_app.Formatters.RawRequestBodyFormatter());
+});
 builder.Services.AddHttpClient().AddHttpClient(Constants.HTTP_CLIENT_IGNORE_SSL_ERROR).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
 {
     ClientCertificateOptions = ClientCertificateOption.Manual,
@@ -87,6 +93,13 @@ logger.LogInformation("Info version is {InfoVersion}", VersionUtils.InfoVersion)
 var forwardingRulesReader = app.Services.GetRequiredService<ForwardingRulesReader>();
 forwardingRulesReader.Init();
 app.Run();
+
+// ensure request buffering middleware is available (optional if already present)
+app.Use(async (context, next) =>
+{
+    context.Request.EnableBuffering();
+    await next();
+});
 
 static void AddEnvironmentVariables(IList<string> existingArgsList, IDictionary<string, string> additionalEnvVars)
 {

--- a/http-forwarder-app/Program.cs
+++ b/http-forwarder-app/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
@@ -40,11 +41,15 @@ builder.Services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo
 builder.Services.AddSingleton<IRestClient, RestClient>();
 builder.Services.AddSingleton<AppState, AppState>();
 builder.Services.AddSingleton<ForwardingRulesReader>();
-builder.Services.AddSingleton<ForwardingService>();
+builder.Services.AddSingleton<IForwardingService, ForwardingService>();
 builder.Services.AddSingleton<IPublisherClientFactory, PublisherClientFactory>();
 builder.Services.AddSingleton<IPublishingService, PublishingService>();
 builder.Services.AddSingleton<CloudMessageHandlerFactory>();
 builder.Services.AddSingleton<RemoteRulePublishingService>();
+builder.Services.AddSingleton<IFailedRequestStorage, FailedRequestStorage>();
+builder.Services.AddHostedService<RetryBackgroundService>();
+builder.Services.AddSingleton<ISystemClock, SystemClock>();
+
 if (builder.Configuration.IsListenerEnabled())
 {
     builder.Services.AddHostedService<BackgroundListeningService>();

--- a/http-forwarder-app/Services/CloudMessageHandler.cs
+++ b/http-forwarder-app/Services/CloudMessageHandler.cs
@@ -14,13 +14,13 @@ namespace http_forwarder_app.Services;
 public class CloudMessageHandler
 {
     private readonly ILogger<CloudMessageHandler> _logger;
-    private readonly ForwardingService _forwardingService;
+    private readonly IForwardingService _forwardingService;
     private readonly RemoteRulePublishingService _remoteRulePublishingService;
     private readonly HashSet<string> _allowedMethods = [HttpMethods.Post, HttpMethods.Put];
 
     public bool CanForwardToTopic { get; init; }
 
-    public CloudMessageHandler(ILogger<CloudMessageHandler> logger, ForwardingService forwardingService, RemoteRulePublishingService remoteRulePublishingService, bool canForwardToTopic, CancellationToken cancellationToken)
+    public CloudMessageHandler(ILogger<CloudMessageHandler> logger, IForwardingService forwardingService, RemoteRulePublishingService remoteRulePublishingService, bool canForwardToTopic, CancellationToken cancellationToken)
     {
         _logger = logger;
         _forwardingService = forwardingService;

--- a/http-forwarder-app/Services/CloudMessageHandler.cs
+++ b/http-forwarder-app/Services/CloudMessageHandler.cs
@@ -72,15 +72,16 @@ public class CloudMessageHandler
         return Task.FromResult(SubscriberClient.Reply.Nack);
     }
 
-    private async Task<SubscriberClient.Reply> ProcessResult(Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> processTask, ForwardingRequest forwardingRequest)
+    private async Task<SubscriberClient.Reply> ProcessResult(Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> processTask, ForwardingRequest forwardingRequest)
     {
         var result = await processTask;
 
         var ackResult = result.Match(
-            respMessage =>
+            respRuleResult =>
             {
                 string eventName = forwardingRequest.Event;
                 string requestMethod = forwardingRequest.Method;
+                var respMessage = respRuleResult.Response;
                 if (respMessage.IsSuccessStatusCode)
                 {
                     _logger.LogInformation("Success ({statusCode}) for event {eventName}, method {requestMethod}", respMessage.StatusCode, eventName, requestMethod);

--- a/http-forwarder-app/Services/CloudMessageHandlerFactory.cs
+++ b/http-forwarder-app/Services/CloudMessageHandlerFactory.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using http_forwarder_app.Models;
 using Microsoft.Extensions.Logging;
 
 namespace http_forwarder_app.Services;
@@ -6,10 +7,10 @@ namespace http_forwarder_app.Services;
 public class CloudMessageHandlerFactory
 {
     private readonly ILogger<CloudMessageHandler> _logger;
-    private readonly ForwardingService _forwardingService;
+    private readonly IForwardingService _forwardingService;
     private readonly RemoteRulePublishingService _remoteRulePublishingService;
 
-    public CloudMessageHandlerFactory(ILogger<CloudMessageHandler> logger, ForwardingService forwardingService, RemoteRulePublishingService remoteRulePublishingService)
+    public CloudMessageHandlerFactory(ILogger<CloudMessageHandler> logger, IForwardingService forwardingService, RemoteRulePublishingService remoteRulePublishingService)
     {
         _logger = logger;
         _forwardingService = forwardingService;

--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.Extensions.Configuration;
 using http_forwarder_app.Models;
 using http_forwarder_app.Core;
+using Google.Protobuf.WellKnownTypes;
 
 namespace http_forwarder_app.Services;
 
@@ -16,7 +17,12 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
 
     public FailedRequestStorage(IConfiguration configuration)
     {
-        _storageFile = configuration["RetryStorage:FilePath"] ?? "failed_requests.json";
+        var storageDir = configuration.GetStorageDirPath() ?? throw new ArgumentNullException("Storage dir path cannot be null. Please set it at RetryStorage:DirPath");
+        if (!Directory.Exists(storageDir))
+        {
+            Directory.CreateDirectory(storageDir);
+        }
+        _storageFile = configuration.GetStorageFilePath();
     }
 
     public void Store(FailedRequest request)
@@ -25,7 +31,24 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
         try
         {
             var requests = Load();
-            requests.Add(request);
+            var index = requests.FindIndex(r => r.Id == request.Id);
+            if (index >= 0)
+            {
+                requests[index] = request;
+                var lastIndex = index;
+                do
+                {
+                    lastIndex = requests.FindLastIndex(r => r.Id == request.Id);
+                    if (lastIndex > index)
+                    {
+                        requests.RemoveAt(lastIndex);
+                    }
+                } while (lastIndex > index);
+            }
+            else
+            {
+                requests.Add(request);
+            }
             File.WriteAllText(_storageFile, JsonUtils.Serialize(requests, true));
         }
         finally
@@ -77,7 +100,12 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
 
     private List<FailedRequest> Load()
     {
-        if (!File.Exists(_storageFile)) return new();
+        if (!File.Exists(_storageFile))
+        {
+            var newContent = new List<FailedRequest>();
+            File.WriteAllText(_storageFile, JsonUtils.Serialize(newContent, true));
+            return newContent;
+        }
         var content = File.ReadAllText(_storageFile);
         return JsonUtils.Deserialize<List<FailedRequest>>(content) ?? new();
     }

--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -21,7 +21,7 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
     public FailedRequestStorage(IConfiguration configuration, ISystemClock clock)
     {
         _clock = clock;
-        var storageDir = configuration.GetStorageDirPath() ?? throw new ArgumentNullException("Storage dir path cannot be null. Please set it at RetryStorage:DirPath");
+        var storageDir = configuration.GetValidStorageDirPath() ?? throw new ArgumentNullException("Storage dir path cannot be null. Please set env variable " + Constants.STORAGE_DIR_PATH);
         if (!Directory.Exists(storageDir))
         {
             Directory.CreateDirectory(storageDir);
@@ -30,6 +30,7 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
     }
 
     public int StorageHash => _storageHash;
+    public event EventHandler StorageUpdated = delegate { };
 
     public void Store(FailedRequest request)
     {
@@ -59,6 +60,7 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
             File.WriteAllText(_storageFile, newContent);
             var newHash = newContent.GetHashCode();
             _storageHash = newHash;
+            StorageUpdated(this, EventArgs.Empty);
         }
         finally
         {
@@ -103,6 +105,7 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
             File.WriteAllText(_storageFile, newContent);
             var newHash = newContent.GetHashCode();
             _storageHash = newHash;
+            StorageUpdated(this, EventArgs.Empty);
         }
         finally
         {

--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Internal;
 using http_forwarder_app.Models;
 using http_forwarder_app.Core;
-using Google.Protobuf.WellKnownTypes;
 
 namespace http_forwarder_app.Services;
 
@@ -14,9 +14,13 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
 {
     private readonly string _storageFile;
     private readonly ReaderWriterLockSlim _lock = new();
+    private readonly ISystemClock _clock;
 
-    public FailedRequestStorage(IConfiguration configuration)
+    private int _storageHash = 0;
+
+    public FailedRequestStorage(IConfiguration configuration, ISystemClock clock)
     {
+        _clock = clock;
         var storageDir = configuration.GetStorageDirPath() ?? throw new ArgumentNullException("Storage dir path cannot be null. Please set it at RetryStorage:DirPath");
         if (!Directory.Exists(storageDir))
         {
@@ -24,6 +28,8 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
         }
         _storageFile = configuration.GetStorageFilePath();
     }
+
+    public int StorageHash => _storageHash;
 
     public void Store(FailedRequest request)
     {
@@ -49,7 +55,10 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
             {
                 requests.Add(request);
             }
-            File.WriteAllText(_storageFile, JsonUtils.Serialize(requests, true));
+            var newContent = JsonUtils.Serialize(requests, true);
+            File.WriteAllText(_storageFile, newContent);
+            var newHash = newContent.GetHashCode();
+            _storageHash = newHash;
         }
         finally
         {
@@ -57,12 +66,12 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
         }
     }
 
-    public List<FailedRequest> GetPendingRequests()
+    public List<FailedRequest> GetRequestsDue(DateTimeOffset? asOf = null)
     {
         _lock.EnterReadLock();
         try
         {
-            return Load().Where(r => r.NextAttempt <= DateTimeOffset.UtcNow).ToList();
+            return Load().Where(r => r.NextAttempt <= (asOf ?? _clock.UtcNow)).ToList();
         }
         finally
         {
@@ -90,7 +99,10 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
         {
             var requests = Load();
             requests.RemoveAll(r => r.Id == requestId);
-            File.WriteAllText(_storageFile, JsonUtils.Serialize(requests, true));
+            var newContent = JsonUtils.Serialize(requests, true);
+            File.WriteAllText(_storageFile, newContent);
+            var newHash = newContent.GetHashCode();
+            _storageHash = newHash;
         }
         finally
         {
@@ -107,6 +119,7 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
             return newContent;
         }
         var content = File.ReadAllText(_storageFile);
+        _storageHash = content.GetHashCode();
         return JsonUtils.Deserialize<List<FailedRequest>>(content) ?? new();
     }
 

--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using http_forwarder_app.Models;
+using http_forwarder_app.Core;
+
+namespace http_forwarder_app.Services;
+
+public class FailedRequestStorage : IFailedRequestStorage, IDisposable
+{
+    private readonly string _storageFile;
+    private readonly ReaderWriterLockSlim _lock = new();
+
+    public FailedRequestStorage(IConfiguration configuration)
+    {
+        _storageFile = configuration["RetryStorage:FilePath"] ?? "failed_requests.json";
+    }
+
+    public void Store(FailedRequest request)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            var requests = Load();
+            requests.Add(request);
+            File.WriteAllText(_storageFile, JsonUtils.Serialize(requests, true));
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public List<FailedRequest> GetPendingRequests()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return Load().Where(r => r.NextAttempt <= DateTimeOffset.UtcNow).ToList();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public List<FailedRequest> GetAllRequests()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return Load();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public void Remove(Guid requestId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            var requests = Load();
+            requests.RemoveAll(r => r.Id == requestId);
+            File.WriteAllText(_storageFile, JsonUtils.Serialize(requests, true));
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    private List<FailedRequest> Load()
+    {
+        if (!File.Exists(_storageFile)) return new();
+        var content = File.ReadAllText(_storageFile);
+        return JsonUtils.Deserialize<List<FailedRequest>>(content) ?? new();
+    }
+
+    public void Dispose()
+    {
+        _lock.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/http-forwarder-app/Services/ForwardingService.cs
+++ b/http-forwarder-app/Services/ForwardingService.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace http_forwarder_app.Services;
 
-public class ForwardingService
+public class ForwardingService : IForwardingService
 {
     private readonly ILogger<ForwardingService> _logger;
     private AppState AppState { get; init; }
@@ -24,27 +24,27 @@ public class ForwardingService
         AppState = appState;
     }
 
-    public Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessGetEvent(string eventName, string? requestHostUrl)
+    public Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessGetEvent(string eventName, string? requestHostUrl)
     {
         return ProcessGetOrDeleteEvent(HttpMethods.Get, eventName, requestHostUrl);
     }
 
-    public Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPostEvent(string eventName, string? requestHostUrl, string requestContent)
+    public Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPostEvent(string eventName, string? requestHostUrl, string requestContent)
     {
         return ProcessPostOrPutEvent(HttpMethods.Post, eventName, requestHostUrl, requestContent);
     }
 
-    public Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPutEvent(string eventName, string? requestHostUrl, string requestContent)
+    public Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPutEvent(string eventName, string? requestHostUrl, string requestContent)
     {
         return ProcessPostOrPutEvent(HttpMethods.Put, eventName, requestHostUrl, requestContent);
     }
 
-    public Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessDeleteEvent(string eventName, string? requestHostUrl)
+    public Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessDeleteEvent(string eventName, string? requestHostUrl)
     {
         return ProcessGetOrDeleteEvent(HttpMethods.Delete, eventName, requestHostUrl);
     }
 
-    private async Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPostOrPutEvent(string method, string eventName, string? requestHostUrl, string requestContent)
+    private async Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPostOrPutEvent(string method, string eventName, string? requestHostUrl, string requestContent)
     {
         if (method != HttpMethods.Post && method != HttpMethods.Put) throw new ArgumentException($"Method {method} is not supported here", nameof(method));
         var fwdRule = RulesReader.Find(method, eventName);
@@ -73,10 +73,11 @@ public class ForwardingService
         var call = method == HttpMethods.Post
                     ? RestClient.MakePostCall(eventName, targetUrl, body, fwdRule.Headers, fwdRule.IgnoreSslError)
                     : RestClient.MakePutCall(eventName, targetUrl, body, fwdRule.Headers, fwdRule.IgnoreSslError);
-        return await call;
+        var response = await call;
+        return new HttpResponseRuleResult(response, fwdRule);
     }
 
-    private async Task<OneOf<HttpResponseMessage, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessGetOrDeleteEvent(string method, string eventName, string? requestHostUrl)
+    private async Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessGetOrDeleteEvent(string method, string eventName, string? requestHostUrl)
     {
         if (method != HttpMethods.Get && method != HttpMethods.Delete) throw new ArgumentException($"Method {method} is not supported here", nameof(method));
         _logger.LogDebug("{method} called with event {eventName}", method, eventName);
@@ -100,7 +101,8 @@ public class ForwardingService
         var call = method == HttpMethods.Get
                     ? RestClient.MakeGetCall(eventName, targetUrl, fwdRule.Headers, fwdRule.IgnoreSslError)
                     : RestClient.MakeDeleteCall(eventName, targetUrl, fwdRule.Headers, fwdRule.IgnoreSslError);
-        return await call;
+        var response = await call;
+        return new HttpResponseRuleResult(response, fwdRule);
     }
 
     private static string GetValidTargetUrl(ForwardingRule rule, string? requestHostUrl)

--- a/http-forwarder-app/Services/ForwardingService.cs
+++ b/http-forwarder-app/Services/ForwardingService.cs
@@ -107,7 +107,7 @@ public class ForwardingService : IForwardingService
 
     private static string GetValidTargetUrl(ForwardingRule rule, string? requestHostUrl)
     {
-        if (rule.TargetUrl != null && !rule.TargetUrl.StartsWith("http", System.StringComparison.Ordinal))
+        if (rule.TargetUrl != null && !rule.TargetUrl.StartsWith("http", StringComparison.Ordinal))
         {
             return $"{requestHostUrl}{rule.TargetUrl}";
         }

--- a/http-forwarder-app/Services/RetryBackgroundService.cs
+++ b/http-forwarder-app/Services/RetryBackgroundService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Internal;
 using http_forwarder_app.Models;
 using http_forwarder_app.Extensions;
+using http_forwarder_app.Core;
 
 namespace http_forwarder_app.Services;
 
@@ -13,74 +15,185 @@ public class RetryBackgroundService : BackgroundService
 {
     private readonly IFailedRequestStorage _storage;
     private readonly IForwardingService _forwardingService;
+    private readonly ITimeDelayService _timeDelayService;
     private readonly ISystemClock _clock;
     private readonly ILogger<RetryBackgroundService> _logger;
+    internal static readonly TimeSpan RetryIntervalMin = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan RetryIntervalMax = TimeSpan.FromHours(1);
+    internal static readonly TimeSpan RetryExpiry = TimeSpan.FromHours(24);
+
 
     public RetryBackgroundService(
         IFailedRequestStorage storage,
         IForwardingService forwardingService,
         ISystemClock clock,
+        ITimeDelayService timeDelayService,
         ILogger<RetryBackgroundService> logger)
     {
         _storage = storage;
+        _timeDelayService = timeDelayService;
         _forwardingService = forwardingService;
         _clock = clock;
         _logger = logger;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    private enum ProcessStatus
     {
+        // Request is successfully processed
+        Success,
+        // Request failed
+        Failed,
+        // Request is invalid
+        Invalid,
+        // Request should be retried
+        TryAgain
+    }
+
+    private async Task ProcessRequestAsync(FailedRequest request)
+    {
+        try
+        {
+            var result = await _forwardingService.ProcessPostEvent(
+                eventName: request.Rule.Event,
+                requestHostUrl: request.RequestHostUrl,
+                requestContent: request.Rule.Content ?? string.Empty);
+
+            ProcessStatus status = await result.Match(
+                ruleResult =>
+                {
+                    if (ruleResult.Response.IsSuccessStatusCode)
+                    {
+                        // Remove request from storage if successful
+                        _storage.Remove(request.Id);
+                        return Task.FromResult(ProcessStatus.Success);
+                    }
+                    if (ruleResult.Response.IsServerError() && ruleResult.Rule.IsRetryable)
+                    {
+                        return Task.FromResult(ProcessStatus.TryAgain);
+                    }
+                    _logger.LogInformation("Request {requestId} for event {eventName} failed with status {statusCode}, but is not a server error. Hence, will be removed from storage",
+                        request.Id,
+                        request.Rule.Event,
+                        ruleResult.Response.StatusCode);
+                    _storage.Remove(request.Id);
+                    return Task.FromResult(ProcessStatus.Failed);
+                },
+                noRule =>
+                {
+                    _logger.LogInformation("Removing request {requestId} with event {eventName} from storage as there is no matching rule", request.Id, request.Rule.Event);
+                    _storage.Remove(request.Id);
+                    return Task.FromResult(ProcessStatus.Invalid);
+                },
+                noBody =>
+                {
+                    _logger.LogInformation("Removing request {requestId} with event {eventName} from storage as there is no body", request.Id, request.Rule.Event);
+                    _storage.Remove(request.Id);
+                    return Task.FromResult(ProcessStatus.Invalid);
+                },
+                remoteRule =>
+                {
+                    _logger.LogInformation("Removing request {requestId} with event {eventName} from storage as it is a remote rule with tags [{tags}]",
+                        request.Id,
+                        request.Rule.Event,
+                        string.Join(", ", remoteRule.RemoteRule.Tags));
+                    _storage.Remove(request.Id);
+                    return Task.FromResult(ProcessStatus.Invalid);
+                }
+            );
+            if (status != ProcessStatus.TryAgain)
+            {
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Retry attempt failed for request {RequestId}", request.Id);
+        }
+
+        // Update retry information
+        var now = _clock.UtcNow;
+        var nextAttempt = request with
+        {
+            AttemptCount = request.AttemptCount + 1,
+            LastAttempt = now,
+            NextAttempt = now.Add(request.AttemptCount.CalculateExponentialDelay(RetryIntervalMin, RetryIntervalMax))
+        };
+
+        if (nextAttempt.NextAttempt > request.FirstAttempt.Add(RetryExpiry))
+        {
+            _logger.LogInformation("Removing request {requestId} with event {eventName} after {attempts} attempts from storage as it has expired", request.Id, request.Rule.Event, request.AttemptCount);
+            _storage.Remove(request.Id);
+        }
+        else
+        {
+            _logger.LogInformation("Re-adding request {requestId} with event {eventName} to storage for attempt {attempts} to be executed at {attemptTime}", request.Id, request.Rule.Event, nextAttempt.AttemptCount, nextAttempt.NextAttempt);
+            _storage.Store(nextAttempt);
+        }
+    }
+
+    // Load and process all pending requests once
+    protected async Task ProcessPendingAsync(DateTimeOffset asOf, CancellationToken stoppingToken)
+    {
+        var pendingNow = _storage.GetRequestsDue(asOf);
+        foreach (var request in pendingNow)
+        {
+            if (stoppingToken.IsCancellationRequested) break;
+
+            await ProcessRequestAsync(request);
+        }
+    }
+
+    private async Task RunAsync(CancellationToken stoppingToken)
+    {
+        var maxWait = RetryIntervalMin;
+        var nextAttempt = DateTimeOffset.MaxValue;
+        int currentHash = 0;
         while (!stoppingToken.IsCancellationRequested)
         {
-            var requests = _storage.GetPendingRequests();
-            foreach (var request in requests)
+            var prevHash = currentHash;
+            currentHash = _storage.StorageHash;
+            var executionTime = _clock.UtcNow;
+            if (currentHash != prevHash || nextAttempt <= executionTime)
             {
+                // Storage has changed or next attempt is due, process any requests that are due now
+                await ProcessPendingAsync(executionTime, stoppingToken);
+
                 try
                 {
-                    var result = await _forwardingService.ProcessPostEvent(
-                        eventName: request.Rule.Event,
-                        requestHostUrl: request.RequestHostUrl,
-                        requestContent: request.Rule.Content ?? string.Empty);
-
-                    await result.Match(
-                        ruleResult =>
-                        {
-                            if (ruleResult.Response.IsSuccessStatusCode)
-                            {
-                                _storage.Remove(request.Id);
-                            }
-                            return Task.CompletedTask;
-                        },
-                        noRule => Task.CompletedTask,
-                        noBody => Task.CompletedTask,
-                        remoteRule => Task.CompletedTask
-                    );
+                    // Get all requests to compute the nearest NextAttempt in the future
+                    var notDue = _storage.GetAllRequests();
+                    var next = notDue
+                        .OrderBy(r => r.NextAttempt)
+                        .FirstOrDefault();
+                    nextAttempt = next?.NextAttempt ?? DateTimeOffset.MaxValue;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Retry attempt failed for request {RequestId}", request.Id);
-                }
-
-                // Update retry information
-                var now = _clock.UtcNow;
-                var nextAttempt = request with
-                {
-                    AttemptCount = request.AttemptCount + 1,
-                    LastAttempt = now,
-                    NextAttempt = now.AddSeconds(request.AttemptCount.CalculateExponentialDelay(30, 3600))
-                };
-
-                if (nextAttempt.NextAttempt > request.FirstAttempt.AddHours(24))
-                {
-                    _storage.Remove(request.Id);
-                }
-                else
-                {
-                    _storage.Store(nextAttempt);
+                    _logger.LogWarning(ex, "Failed to compute next retry time from storage. Falling back to periodic wake.");
                 }
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            var currentTime = _clock.UtcNow;
+            TimeSpan? waitUntil = null;
+            if (nextAttempt != DateTimeOffset.MaxValue)
+            {
+                waitUntil = nextAttempt - currentTime;
+                if (waitUntil < TimeSpan.Zero)
+                {
+                    waitUntil = TimeSpan.Zero;
+                }
+            }
+
+            var delay = waitUntil.HasValue
+                ? (waitUntil.Value < maxWait ? waitUntil.Value : maxWait)
+                : maxWait;
+            var delayTask = _timeDelayService.DelayAsync(delay, stoppingToken);
+            await delayTask.IgnoreCancellation();
         }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await RunAsync(stoppingToken);
     }
 }

--- a/http-forwarder-app/Services/RetryBackgroundService.cs
+++ b/http-forwarder-app/Services/RetryBackgroundService.cs
@@ -37,7 +37,10 @@ public class RetryBackgroundService : BackgroundService
             {
                 try
                 {
-                    var result = await _forwardingService.ProcessPostEvent(request.Rule.Event, null, request.Rule.Content ?? string.Empty);
+                    var result = await _forwardingService.ProcessPostEvent(
+                        eventName: request.Rule.Event,
+                        requestHostUrl: request.RequestHostUrl,
+                        requestContent: request.Rule.Content ?? string.Empty);
 
                     await result.Match(
                         ruleResult =>

--- a/http-forwarder-app/Services/RetryBackgroundService.cs
+++ b/http-forwarder-app/Services/RetryBackgroundService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Internal;
+using http_forwarder_app.Models;
+using http_forwarder_app.Extensions;
+
+namespace http_forwarder_app.Services;
+
+public class RetryBackgroundService : BackgroundService
+{
+    private readonly IFailedRequestStorage _storage;
+    private readonly IForwardingService _forwardingService;
+    private readonly ISystemClock _clock;
+    private readonly ILogger<RetryBackgroundService> _logger;
+
+    public RetryBackgroundService(
+        IFailedRequestStorage storage,
+        IForwardingService forwardingService,
+        ISystemClock clock,
+        ILogger<RetryBackgroundService> logger)
+    {
+        _storage = storage;
+        _forwardingService = forwardingService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var requests = _storage.GetPendingRequests();
+            foreach (var request in requests)
+            {
+                try
+                {
+                    var result = await _forwardingService.ProcessPostEvent(request.Rule.Event, null, request.Rule.Content ?? string.Empty);
+
+                    await result.Match(
+                        ruleResult =>
+                        {
+                            if (ruleResult.Response.IsSuccessStatusCode)
+                            {
+                                _storage.Remove(request.Id);
+                            }
+                            return Task.CompletedTask;
+                        },
+                        noRule => Task.CompletedTask,
+                        noBody => Task.CompletedTask,
+                        remoteRule => Task.CompletedTask
+                    );
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Retry attempt failed for request {RequestId}", request.Id);
+                }
+
+                // Update retry information
+                var now = _clock.UtcNow;
+                var nextAttempt = request with
+                {
+                    AttemptCount = request.AttemptCount + 1,
+                    LastAttempt = now,
+                    NextAttempt = now.AddSeconds(request.AttemptCount.CalculateExponentialDelay(30, 3600))
+                };
+
+                if (nextAttempt.NextAttempt > request.FirstAttempt.AddHours(24))
+                {
+                    _storage.Remove(request.Id);
+                }
+                else
+                {
+                    _storage.Store(nextAttempt);
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+        }
+    }
+}

--- a/http-forwarder-app/Services/RetryBackgroundService.cs
+++ b/http-forwarder-app/Services/RetryBackgroundService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Internal;
 using http_forwarder_app.Models;
 using http_forwarder_app.Extensions;
 using http_forwarder_app.Core;
+using Microsoft.Extensions.Configuration;
 
 namespace http_forwarder_app.Services;
 
@@ -20,7 +21,10 @@ public class RetryBackgroundService : BackgroundService
     private readonly ILogger<RetryBackgroundService> _logger;
     internal static readonly TimeSpan RetryIntervalMin = TimeSpan.FromSeconds(30);
     internal static readonly TimeSpan RetryIntervalMax = TimeSpan.FromHours(1);
+    private readonly int _maxConcurrency;
     internal static readonly TimeSpan RetryExpiry = TimeSpan.FromHours(24);
+
+    private CancellationTokenSource _waitTokenSource;
 
 
     public RetryBackgroundService(
@@ -28,13 +32,16 @@ public class RetryBackgroundService : BackgroundService
         IForwardingService forwardingService,
         ISystemClock clock,
         ITimeDelayService timeDelayService,
-        ILogger<RetryBackgroundService> logger)
+        ILogger<RetryBackgroundService> logger,
+        IConfiguration configuration)
     {
         _storage = storage;
         _timeDelayService = timeDelayService;
         _forwardingService = forwardingService;
         _clock = clock;
         _logger = logger;
+        _maxConcurrency = configuration.GetRetryMaxConcurrency();
+        _waitTokenSource = new CancellationTokenSource();
     }
 
     private enum ProcessStatus
@@ -135,25 +142,46 @@ public class RetryBackgroundService : BackgroundService
     protected async Task ProcessPendingAsync(DateTimeOffset asOf, CancellationToken stoppingToken)
     {
         var pendingNow = _storage.GetRequestsDue(asOf);
-        foreach (var request in pendingNow)
+        if (pendingNow.Any())
         {
-            if (stoppingToken.IsCancellationRequested) break;
-
-            await ProcessRequestAsync(request);
+            var parallelOptions = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = _maxConcurrency,
+                CancellationToken = stoppingToken
+            };
+            await Parallel.ForEachAsync(pendingNow, parallelOptions, async (request, token) =>
+            {
+                await ProcessRequestAsync(request);
+            });
         }
+    }
+
+    private void OnStorageUpdated(object? sender, EventArgs e)
+    {
+        _waitTokenSource.Cancel();
     }
 
     private async Task RunAsync(CancellationToken stoppingToken)
     {
-        var maxWait = RetryIntervalMin;
+        var maxWait = RetryIntervalMax;
         var nextAttempt = DateTimeOffset.MaxValue;
         int currentHash = 0;
+        _storage.StorageUpdated -= OnStorageUpdated;
+        _storage.StorageUpdated += OnStorageUpdated;
+
         while (!stoppingToken.IsCancellationRequested)
         {
             var prevHash = currentHash;
-            currentHash = _storage.StorageHash;
+
+            var waitTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            var prevWaitTokenSource = Interlocked.Exchange(ref _waitTokenSource, waitTokenSource);
+            var prevWaitCancellationRequested = prevWaitTokenSource.IsCancellationRequested;
+            prevWaitTokenSource?.Dispose();
+
             var executionTime = _clock.UtcNow;
-            if (currentHash != prevHash || nextAttempt <= executionTime)
+            currentHash = _storage.StorageHash;
+
+            if (currentHash != prevHash || nextAttempt <= executionTime || waitTokenSource.IsCancellationRequested || prevWaitCancellationRequested)
             {
                 // Storage has changed or next attempt is due, process any requests that are due now
                 await ProcessPendingAsync(executionTime, stoppingToken);
@@ -187,9 +215,11 @@ public class RetryBackgroundService : BackgroundService
             var delay = waitUntil.HasValue
                 ? (waitUntil.Value < maxWait ? waitUntil.Value : maxWait)
                 : maxWait;
-            var delayTask = _timeDelayService.DelayAsync(delay, stoppingToken);
+
+            var delayTask = _timeDelayService.DelayAsync(delay, waitTokenSource.Token);
             await delayTask.IgnoreCancellation();
         }
+        _storage.StorageUpdated -= OnStorageUpdated;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/http-forwarder-app/Services/TimeDelayService.cs
+++ b/http-forwarder-app/Services/TimeDelayService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using http_forwarder_app.Models;
+
+namespace http_forwarder_app.Services;
+
+public class TimeDelayService : ITimeDelayService
+{
+    public Task DelayAsync(TimeSpan duration, CancellationToken cancellationToken)
+    {
+        return Task.Delay(duration, cancellationToken);
+    }
+}

--- a/http-forwarder-app/conf/rules.json
+++ b/http-forwarder-app/conf/rules.json
@@ -18,6 +18,7 @@
             "Content-Type": "application/json"
         },
         "hasContent": false,
+        "isRetryable": false,
         "tags": [
             "local",
             "home",
@@ -43,6 +44,7 @@
             "Content-Type": "application/json"
         },
         "hasContent": false,
+        "isRetryable": false,
         "tags": [
             "local",
             "home",
@@ -57,6 +59,7 @@
         "headers": {
             "Content-Type": "application/json"
         },
+        "isRetryable": false,
         "tags": [
             "local",
             "home",
@@ -88,6 +91,7 @@
             "Content-Type": "application/json"
         },
         "hasContent": false,
+        "isRetryable": false,
         "tags": [
             "cloud"
         ]

--- a/http-forwarder-app/conf/rules.json
+++ b/http-forwarder-app/conf/rules.json
@@ -51,6 +51,22 @@
     },
     {
         "method": "POST",
+        "event": "ping-fail",
+        "targetUrl": "/api/ping",
+        "content": "{\"message\": \"FAIL\"}",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "hasContent": false,
+        "isRetryable": true,
+        "tags": [
+            "local",
+            "home",
+            "cloud"
+        ]
+    },
+    {
+        "method": "POST",
         "event": "cloud-test",
         "targetUrl": "/api/cloud",
         "content": "{\"message\": \"cloud-message-567\"}",

--- a/http-forwarder-app/conf/rules.json
+++ b/http-forwarder-app/conf/rules.json
@@ -51,6 +51,20 @@
     },
     {
         "method": "POST",
+        "event": "ping-request",
+        "targetUrl": "/api/ping",
+        "hasContent": true,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "tags": [
+            "local",
+            "home",
+            "cloud"
+        ]
+    },
+    {
+        "method": "POST",
         "event": "ping-fail",
         "targetUrl": "/api/ping",
         "content": "{\"message\": \"FAIL\"}",

--- a/http-forwarder-models/Constants.cs
+++ b/http-forwarder-models/Constants.cs
@@ -21,4 +21,8 @@ public static class Constants
     public const string TOPIC_ID_PREFIX = "PUBSUB_TOPIC_ID_";
 
     public const string GENERIC_TOPIC_ALLOWED_EVENTS = "ALLOWED_EVENTS";
+
+    public const string STORAGE_DIR_PATH = "STORAGE_DIR_PATH";
+
+    public const string RETRY_POLICY_MAX_CONCURRENCY = "RETRY_POLICY_MAX_CONCURRENCY";
 }

--- a/http-forwarder-models/FailedRequest.cs
+++ b/http-forwarder-models/FailedRequest.cs
@@ -3,6 +3,7 @@ namespace http_forwarder_app.Models;
 public record class FailedRequest(
     Guid Id,
     ForwardingRule Rule,
+    string RequestHostUrl,
     DateTimeOffset FirstAttempt,
     DateTimeOffset LastAttempt,
     int AttemptCount,

--- a/http-forwarder-models/FailedRequest.cs
+++ b/http-forwarder-models/FailedRequest.cs
@@ -1,0 +1,11 @@
+namespace http_forwarder_app.Models;
+
+public record class FailedRequest(
+    Guid Id,
+    ForwardingRule Rule,
+    DateTimeOffset FirstAttempt,
+    DateTimeOffset LastAttempt,
+    int AttemptCount,
+    DateTimeOffset NextAttempt,
+    string? LastError
+);

--- a/http-forwarder-models/ForwardingResult.cs
+++ b/http-forwarder-models/ForwardingResult.cs
@@ -1,0 +1,4 @@
+namespace http_forwarder_app.Models;
+
+public record ForwardingSuccess;
+public record ForwardingFailure(string Error);

--- a/http-forwarder-models/ForwardingRule.cs
+++ b/http-forwarder-models/ForwardingRule.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace http_forwarder_app.Models;
 
-public record class ForwardingRule(string Method, string Event, string TargetUrl, [DefaultValue(true)] bool HasContent = true, string? Content = null, bool IgnoreSslError = false, Dictionary<string, string>? Headers = default, HashSet<string>? Tags = default)
+public record class ForwardingRule(string Method, string Event, string TargetUrl, [DefaultValue(true)] bool HasContent = true, string? Content = null, bool IgnoreSslError = false, Dictionary<string, string>? Headers = default, HashSet<string>? Tags = default, [DefaultValue(false)] bool IsRetryable = false)
 {
     public Dictionary<string, string> Headers { get; init; } = Headers ?? [];
 

--- a/http-forwarder-models/HttpResponseRuleResult.cs
+++ b/http-forwarder-models/HttpResponseRuleResult.cs
@@ -1,0 +1,5 @@
+using System.Net.Http;
+
+namespace http_forwarder_app.Models;
+
+public record HttpResponseRuleResult(HttpResponseMessage Response, ForwardingRule Rule);

--- a/http-forwarder-models/IFailedRequestStorage.cs
+++ b/http-forwarder-models/IFailedRequestStorage.cs
@@ -3,6 +3,7 @@ namespace http_forwarder_app.Models;
 public interface IFailedRequestStorage
 {
     int StorageHash { get; }
+    event EventHandler StorageUpdated;
     void Store(FailedRequest request);
     List<FailedRequest> GetRequestsDue(DateTimeOffset? asOf = null);
     List<FailedRequest> GetAllRequests();

--- a/http-forwarder-models/IFailedRequestStorage.cs
+++ b/http-forwarder-models/IFailedRequestStorage.cs
@@ -1,0 +1,9 @@
+namespace http_forwarder_app.Models;
+
+public interface IFailedRequestStorage
+{
+    void Store(FailedRequest request);
+    List<FailedRequest> GetPendingRequests();
+    List<FailedRequest> GetAllRequests();
+    void Remove(Guid requestId);
+}

--- a/http-forwarder-models/IFailedRequestStorage.cs
+++ b/http-forwarder-models/IFailedRequestStorage.cs
@@ -2,8 +2,9 @@ namespace http_forwarder_app.Models;
 
 public interface IFailedRequestStorage
 {
+    int StorageHash { get; }
     void Store(FailedRequest request);
-    List<FailedRequest> GetPendingRequests();
+    List<FailedRequest> GetRequestsDue(DateTimeOffset? asOf = null);
     List<FailedRequest> GetAllRequests();
     void Remove(Guid requestId);
 }

--- a/http-forwarder-models/IForwardingService.cs
+++ b/http-forwarder-models/IForwardingService.cs
@@ -1,0 +1,11 @@
+using OneOf;
+
+namespace http_forwarder_app.Models;
+
+public interface IForwardingService
+{
+    Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessGetEvent(string eventName, string? requestHostUrl);
+    Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPostEvent(string eventName, string? requestHostUrl, string requestContent);
+    Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, NoBodyRuleResult, RemoteRuleFoundResult>> ProcessPutEvent(string eventName, string? requestHostUrl, string requestContent);
+    Task<OneOf<HttpResponseRuleResult, NoMatchingRuleResult, RemoteRuleFoundResult>> ProcessDeleteEvent(string eventName, string? requestHostUrl);
+}

--- a/http-forwarder-models/ITimeDelayServoce.cs
+++ b/http-forwarder-models/ITimeDelayServoce.cs
@@ -1,0 +1,6 @@
+namespace http_forwarder_app.Models;
+
+public interface ITimeDelayService
+{
+    Task DelayAsync(TimeSpan duration, CancellationToken cancellationToken);
+}

--- a/http-forwarder-unit-tests/FailedRequestStorageTests.cs
+++ b/http-forwarder-unit-tests/FailedRequestStorageTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using http_forwarder_app.Models;
-using Microsoft.Extensions.Internal;
 using http_forwarder_app.Services;
 using Shouldly;
 
@@ -11,15 +10,19 @@ namespace http_forwarder_unit_tests;
 
 public class FailedRequestStorageTests : IDisposable
 {
+    private readonly string _storageDir;
     private readonly string _testFilePath;
     private readonly FailedRequestStorage _storage;
 
     public FailedRequestStorageTests()
     {
-        _testFilePath = Path.Combine(Path.GetTempPath(), $"test_failed_requests_{Guid.NewGuid()}.json");
         var configMock = new Mock<IConfiguration>();
-        configMock.Setup(x => x["RetryStorage:FilePath"]).Returns(_testFilePath);
+        var storageDir = Path.Combine(Path.GetTempPath(), $"http_forwarder_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(storageDir);
+        configMock.Setup(x => x["RetryStorage:DirPath"]).Returns(storageDir);
         _storage = new FailedRequestStorage(configMock.Object);
+        _storageDir = storageDir;
+        _testFilePath = Path.Combine(_storageDir, "storage.json");
     }
 
     [Fact]
@@ -91,6 +94,26 @@ public class FailedRequestStorageTests : IDisposable
         remaining[0].Id.ShouldBe(request2.Id);
     }
 
+    [Fact]
+    public void Updated_ShouldUpdateRequest()
+    {
+        // Arrange
+        var request1 = CreateTestRequest();
+        var request2 = CreateTestRequest();
+        _storage.Store(request1);
+        _storage.Store(request2);
+
+        // Act
+        var updatedRequest1 = request1 with { LastError = "Updated error", AttemptCount = request1.AttemptCount + 1, LastAttempt = DateTimeOffset.UtcNow, NextAttempt = DateTimeOffset.UtcNow.AddSeconds(30) };
+        _storage.Store(updatedRequest1);
+
+        // Assert
+        var remaining = _storage.GetAllRequests();
+        remaining.Count.ShouldBe(2);
+        remaining[0].Id.ShouldBe(request1.Id);
+        remaining[1].Id.ShouldBe(request2.Id);
+    }
+
     private static FailedRequest CreateTestRequest(DateTimeOffset? nextAttempt = null)
     {
         var rule = new ForwardingRule(
@@ -105,6 +128,7 @@ public class FailedRequestStorageTests : IDisposable
         return new FailedRequest(
             Id: Guid.NewGuid(),
             Rule: rule,
+            RequestHostUrl: "http://locahost:5000",
             FirstAttempt: DateTimeOffset.UtcNow,
             LastAttempt: DateTimeOffset.UtcNow,
             AttemptCount: 1,
@@ -115,9 +139,9 @@ public class FailedRequestStorageTests : IDisposable
 
     public void Dispose()
     {
-        if (File.Exists(_testFilePath))
+        if (Directory.Exists(_storageDir))
         {
-            File.Delete(_testFilePath);
+            Directory.Delete(_storageDir, true);
         }
     }
 }

--- a/http-forwarder-unit-tests/FailedRequestStorageTests.cs
+++ b/http-forwarder-unit-tests/FailedRequestStorageTests.cs
@@ -7,6 +7,7 @@ using http_forwarder_app.Services;
 using Shouldly;
 using Microsoft.Extensions.Internal;
 using Microsoft.AspNetCore.Mvc.Diagnostics;
+using http_forwarder_app;
 
 namespace http_forwarder_unit_tests;
 
@@ -21,14 +22,19 @@ public class FailedRequestStorageTests : IDisposable
     public FailedRequestStorageTests()
     {
         var configMock = new Mock<IConfiguration>();
-        var storageDir = Path.Combine(Path.GetTempPath(), $"http_forwarder_test_{Guid.NewGuid()}");
+        _storageDir = Path.Combine(Path.GetTempPath(), $"http_forwarder_test_{Guid.NewGuid()}");
+        var storageDir = _storageDir;
         Directory.CreateDirectory(storageDir);
-        configMock.Setup(x => x["RetryStorage:DirPath"]).Returns(storageDir);
+
+        var configSectionMock = new Mock<IConfigurationSection>();
+        configSectionMock.Setup(x => x.Value).Returns(storageDir);
+        configMock.Setup(x => x.GetSection(It.Is<string>(s => s.EndsWith("GetAppRoot")))).Returns(configSectionMock.Object);
+        configMock.Setup(x => x.GetSection(Constants.STORAGE_DIR_PATH)).Returns(configSectionMock.Object);
+
         var mockClock = new Mock<ISystemClock>();
         _startTime = DateTimeOffset.UtcNow;
         mockClock.Setup(x => x.UtcNow).Returns(_startTime);
         _storage = new FailedRequestStorage(configMock.Object, mockClock.Object);
-        _storageDir = storageDir;
         _testFilePath = Path.Combine(_storageDir, "storage.json");
     }
 

--- a/http-forwarder-unit-tests/FailedRequestStorageTests.cs
+++ b/http-forwarder-unit-tests/FailedRequestStorageTests.cs
@@ -5,6 +5,8 @@ using Moq;
 using http_forwarder_app.Models;
 using http_forwarder_app.Services;
 using Shouldly;
+using Microsoft.Extensions.Internal;
+using Microsoft.AspNetCore.Mvc.Diagnostics;
 
 namespace http_forwarder_unit_tests;
 
@@ -13,6 +15,8 @@ public class FailedRequestStorageTests : IDisposable
     private readonly string _storageDir;
     private readonly string _testFilePath;
     private readonly FailedRequestStorage _storage;
+    private readonly DateTimeOffset _startTime;
+
 
     public FailedRequestStorageTests()
     {
@@ -20,7 +24,10 @@ public class FailedRequestStorageTests : IDisposable
         var storageDir = Path.Combine(Path.GetTempPath(), $"http_forwarder_test_{Guid.NewGuid()}");
         Directory.CreateDirectory(storageDir);
         configMock.Setup(x => x["RetryStorage:DirPath"]).Returns(storageDir);
-        _storage = new FailedRequestStorage(configMock.Object);
+        var mockClock = new Mock<ISystemClock>();
+        _startTime = DateTimeOffset.UtcNow;
+        mockClock.Setup(x => x.UtcNow).Returns(_startTime);
+        _storage = new FailedRequestStorage(configMock.Object, mockClock.Object);
         _storageDir = storageDir;
         _testFilePath = Path.Combine(_storageDir, "storage.json");
     }
@@ -62,13 +69,13 @@ public class FailedRequestStorageTests : IDisposable
     public void GetPendingRequests_ShouldReturnRequestsDueForRetry()
     {
         // Arrange
-        var pastRequest = CreateTestRequest(DateTimeOffset.UtcNow.AddMinutes(-5));
-        var futureRequest = CreateTestRequest(DateTimeOffset.UtcNow.AddMinutes(5));
+        var pastRequest = CreateTestRequest(_startTime.AddMinutes(-5));
+        var futureRequest = CreateTestRequest(_startTime.AddMinutes(5));
         _storage.Store(pastRequest);
         _storage.Store(futureRequest);
 
         // Act
-        var pending = _storage.GetPendingRequests();
+        var pending = _storage.GetRequestsDue(_startTime);
 
         // Assert
         pending.Count.ShouldBe(1);
@@ -79,7 +86,7 @@ public class FailedRequestStorageTests : IDisposable
     public void Remove_ShouldDeleteRequest()
     {
         // Arrange
-        var pastTime = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var pastTime = _startTime.AddMinutes(-5);
         var request1 = CreateTestRequest(pastTime);
         var request2 = CreateTestRequest(pastTime);
         _storage.Store(request1);
@@ -114,7 +121,7 @@ public class FailedRequestStorageTests : IDisposable
         remaining[1].Id.ShouldBe(request2.Id);
     }
 
-    private static FailedRequest CreateTestRequest(DateTimeOffset? nextAttempt = null)
+    private FailedRequest CreateTestRequest(DateTimeOffset? nextAttempt = null)
     {
         var rule = new ForwardingRule(
             Method: "POST",
@@ -129,10 +136,10 @@ public class FailedRequestStorageTests : IDisposable
             Id: Guid.NewGuid(),
             Rule: rule,
             RequestHostUrl: "http://locahost:5000",
-            FirstAttempt: DateTimeOffset.UtcNow,
-            LastAttempt: DateTimeOffset.UtcNow,
+            FirstAttempt: _startTime,
+            LastAttempt: _startTime,
             AttemptCount: 1,
-            NextAttempt: nextAttempt ?? DateTimeOffset.UtcNow.AddMinutes(1),
+            NextAttempt: nextAttempt ?? _startTime.AddMinutes(1),
             LastError: "test error"
         );
     }

--- a/http-forwarder-unit-tests/FailedRequestStorageTests.cs
+++ b/http-forwarder-unit-tests/FailedRequestStorageTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using http_forwarder_app.Models;
+using Microsoft.Extensions.Internal;
+using http_forwarder_app.Services;
+using Shouldly;
+
+namespace http_forwarder_unit_tests;
+
+public class FailedRequestStorageTests : IDisposable
+{
+    private readonly string _testFilePath;
+    private readonly FailedRequestStorage _storage;
+
+    public FailedRequestStorageTests()
+    {
+        _testFilePath = Path.Combine(Path.GetTempPath(), $"test_failed_requests_{Guid.NewGuid()}.json");
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(x => x["RetryStorage:FilePath"]).Returns(_testFilePath);
+        _storage = new FailedRequestStorage(configMock.Object);
+    }
+
+    [Fact]
+    public void Store_ShouldPersistRequest()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+
+        // Act
+        _storage.Store(request);
+
+        // Assert
+        var stored = File.ReadAllText(_testFilePath);
+        stored.ShouldContain(request.Id.ToString());
+        stored.ShouldContain(request.Rule.Event);
+    }
+
+    [Fact]
+    public void Store_ShouldLoadRequests()
+    {
+        // Arrange
+        var request1 = CreateTestRequest();
+        var request2 = CreateTestRequest();
+
+        // Act
+        _storage.Store(request1);
+        _storage.Store(request2);
+
+        // Assert
+        var stored = _storage.GetAllRequests();
+        stored.Count.ShouldBe(2);
+        stored.ShouldContain(r => r.Id == request1.Id);
+        stored.ShouldContain(r => r.Id == request2.Id);
+    }
+
+    [Fact]
+    public void GetPendingRequests_ShouldReturnRequestsDueForRetry()
+    {
+        // Arrange
+        var pastRequest = CreateTestRequest(DateTimeOffset.UtcNow.AddMinutes(-5));
+        var futureRequest = CreateTestRequest(DateTimeOffset.UtcNow.AddMinutes(5));
+        _storage.Store(pastRequest);
+        _storage.Store(futureRequest);
+
+        // Act
+        var pending = _storage.GetPendingRequests();
+
+        // Assert
+        pending.Count.ShouldBe(1);
+        pending[0].Id.ShouldBe(pastRequest.Id);
+    }
+
+    [Fact]
+    public void Remove_ShouldDeleteRequest()
+    {
+        // Arrange
+        var pastTime = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var request1 = CreateTestRequest(pastTime);
+        var request2 = CreateTestRequest(pastTime);
+        _storage.Store(request1);
+        _storage.Store(request2);
+
+        // Act
+        _storage.Remove(request1.Id);
+
+        // Assert
+        var remaining = _storage.GetAllRequests();
+        remaining.Count.ShouldBe(1);
+        remaining[0].Id.ShouldBe(request2.Id);
+    }
+
+    private static FailedRequest CreateTestRequest(DateTimeOffset? nextAttempt = null)
+    {
+        var rule = new ForwardingRule(
+            Method: "POST",
+            Event: "test-event",
+            TargetUrl: "http://test.com",
+            HasContent: true,
+            Content: "test-content",
+            IsRetryable: true
+        );
+
+        return new FailedRequest(
+            Id: Guid.NewGuid(),
+            Rule: rule,
+            FirstAttempt: DateTimeOffset.UtcNow,
+            LastAttempt: DateTimeOffset.UtcNow,
+            AttemptCount: 1,
+            NextAttempt: nextAttempt ?? DateTimeOffset.UtcNow.AddMinutes(1),
+            LastError: "test error"
+        );
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+}

--- a/http-forwarder-unit-tests/RetryExtensionsTests.cs
+++ b/http-forwarder-unit-tests/RetryExtensionsTests.cs
@@ -1,0 +1,35 @@
+using System;
+using http_forwarder_app.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace http_forwarder_unit_tests;
+
+public class RetryExtensionsTests
+{
+    private readonly TimeSpan _baseDelay = TimeSpan.FromSeconds(30);
+    private readonly TimeSpan _maxDelay = TimeSpan.FromHours(1);
+
+    [Theory]
+    [InlineData(1, 30)]    // 30 * 2^0 = 30
+    [InlineData(2, 60)]    // 30 * 2^1 = 60
+    [InlineData(3, 120)]   // 30 * 2^2 = 120
+    [InlineData(4, 240)]   // 30 * 2^3 = 240
+    [InlineData(5, 480)]   // 30 * 2^4 = 480
+    [InlineData(6, 960)]   // 30 * 2^5 = 960
+    [InlineData(7, 1920)]  // 30 * 2^6 = 1920
+    [InlineData(8, 3600)]  // 30 * 2^7 = 3840, capped at 3600
+    [InlineData(9, 3600)]  // 30 * 2^8 = 7680, capped at 3600
+    [InlineData(10, 3600)] // Stays at max
+    public void CalculateExponentialDelay_ShouldCalculateCorrectDelay(int attemptCount, int expectedDelaySeconds)
+    {
+        // Arrange
+        var expectedDelay = TimeSpan.FromSeconds(expectedDelaySeconds);
+
+        // Act
+        var actualDelay = attemptCount.CalculateExponentialDelay(_baseDelay, _maxDelay);
+
+        // Assert
+        actualDelay.ShouldBe(expectedDelay);
+    }
+}

--- a/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
+++ b/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Moq;
+using http_forwarder_app.Models;
+using http_forwarder_app.Services;
+using OneOf;
+
+namespace http_forwarder_unit_tests;
+
+public class RetryBackgroundServiceTests
+{
+    private readonly Mock<IFailedRequestStorage> _storageMock;
+    private readonly Mock<IForwardingService> _forwardingServiceMock;
+    private readonly Mock<ISystemClock> _clockMock;
+    private readonly Mock<ILogger<RetryBackgroundService>> _loggerMock;
+    private readonly RetryBackgroundService _service;
+    private readonly CancellationTokenSource _cts;
+
+    public RetryBackgroundServiceTests()
+    {
+        _storageMock = new Mock<IFailedRequestStorage>();
+        _forwardingServiceMock = new Mock<IForwardingService>();
+        _clockMock = new Mock<ISystemClock>();
+        _loggerMock = new Mock<ILogger<RetryBackgroundService>>();
+        _cts = new CancellationTokenSource();
+
+        var currentTime = DateTimeOffset.UtcNow;
+        _clockMock.Setup(x => x.UtcNow).Returns(currentTime);
+
+        _service = new RetryBackgroundService(
+            _storageMock.Object,
+            _forwardingServiceMock.Object,
+            _clockMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRetryFailedRequests()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetPendingRequests())
+            .Returns(new List<FailedRequest> { request });
+
+        var successResult = new HttpResponseRuleResult(
+            new HttpResponseMessage(System.Net.HttpStatusCode.OK),
+            request.Rule);
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(successResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.StartAsync(_cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldUpdateRetryInfoOnFailure()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetPendingRequests())
+            .Returns(new List<FailedRequest> { request });
+
+        var failureResult = new HttpResponseRuleResult(
+            new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError),
+            request.Rule);
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(failureResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.StartAsync(_cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Store(It.Is<FailedRequest>(r =>
+            r.Id == request.Id &&
+            r.AttemptCount == request.AttemptCount + 1)),
+            Times.Once);
+    }
+
+    private FailedRequest CreateTestRequest()
+    {
+        var rule = new ForwardingRule(
+            Method: "POST",
+            Event: "test-event",
+            TargetUrl: "http://test.com",
+            HasContent: true,
+            Content: "test-content",
+            IsRetryable: true);
+
+        return new FailedRequest(
+            Id: Guid.NewGuid(),
+            Rule: rule,
+            FirstAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
+            LastAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
+            AttemptCount: 1,
+            NextAttempt: _clockMock.Object.UtcNow.AddMinutes(-1),
+            LastError: "test error");
+    }
+}

--- a/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
+++ b/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -8,6 +9,7 @@ using http_forwarder_app.Models;
 using http_forwarder_app.Services;
 using OneOf;
 using Shouldly;
+using http_forwarder_app;
 
 namespace http_forwarder_unit_tests;
 
@@ -19,6 +21,7 @@ public class RetryBackgroundServiceTests
     private readonly Mock<ITimeDelayService> _delayServiceMock;
     private readonly Mock<ILogger<RetryBackgroundService>> _loggerMock;
     private readonly TestableRetryBackgroundService _service;
+    private readonly Mock<IConfiguration> _configMock;
     private readonly CancellationTokenSource _cts;
     private readonly DateTimeOffset _startTime;
 
@@ -30,18 +33,23 @@ public class RetryBackgroundServiceTests
         _clockMock = new Mock<ISystemClock>();
         _delayServiceMock = new Mock<ITimeDelayService>();
         _loggerMock = new Mock<ILogger<RetryBackgroundService>>();
+        _configMock = new Mock<IConfiguration>(MockBehavior.Loose);
         _cts = new CancellationTokenSource();
         _startTime = DateTimeOffset.UtcNow;
 
-
         _clockMock.Setup(x => x.UtcNow).Returns(_startTime);
+        var configSectionMock = new Mock<IConfigurationSection>(MockBehavior.Loose);
+        configSectionMock.Setup(x => x.Value).Returns("1");
+        _configMock.Setup(x => x.GetSection(Constants.RETRY_POLICY_MAX_CONCURRENCY))
+            .Returns(configSectionMock.Object);
 
         _service = new TestableRetryBackgroundService(
             _storageMock.Object,
             _forwardingServiceMock.Object,
             _clockMock.Object,
             _delayServiceMock.Object,
-            _loggerMock.Object);
+            _loggerMock.Object,
+            _configMock.Object);
     }
 
     [Fact]
@@ -137,7 +145,7 @@ public class RetryBackgroundServiceTests
         _storageMock.Setup(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>())).Returns([]);
         _storageMock.Setup(s => s.StorageHash).Returns(1);
 
-        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .Callback(() => _cts.Cancel()) // Cancel on first delay to exit loop
             .Returns(Task.CompletedTask);
 
@@ -149,7 +157,7 @@ public class RetryBackgroundServiceTests
         _storageMock.Verify(s => s.GetAllRequests(), Times.Once);
         _storageMock.Verify(x => x.Remove(It.IsAny<Guid>()), Times.Never);
         _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
-        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Once);
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromHours(1), It.IsAny<CancellationToken>()), Times.Once);
         _forwardingServiceMock.Verify(f => f.ProcessPostEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
@@ -166,7 +174,7 @@ public class RetryBackgroundServiceTests
         _forwardingServiceMock.Setup(f => f.ProcessPostEvent(request.Rule.Event, request.RequestHostUrl, request.Rule.Content!))
             .ReturnsAsync(successResult);
 
-        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .Callback(() => _cts.Cancel())
             .Returns(Task.CompletedTask);
 
@@ -177,7 +185,7 @@ public class RetryBackgroundServiceTests
         _storageMock.Verify(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>()), Times.Once);
         _forwardingServiceMock.Verify(f => f.ProcessPostEvent(request.Rule.Event, request.RequestHostUrl, request.Rule.Content!), Times.Once);
         _storageMock.Verify(s => s.Remove(request.Id), Times.Once);
-        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Once);
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromHours(1), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -196,8 +204,8 @@ public class RetryBackgroundServiceTests
 
         _storageMock.Setup(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>())).Returns([]);
 
-        int delayCallCount = 0;
-        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+        var delayCallCount = 0;
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .Callback<TimeSpan, CancellationToken>((delay, token) =>
             {
                 delayCallCount++;
@@ -219,7 +227,7 @@ public class RetryBackgroundServiceTests
         // Assert
         _storageMock.Verify(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>()), Times.Exactly(2));
         _storageMock.Verify(s => s.GetAllRequests(), Times.Exactly(2));
-        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Exactly(2));
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromHours(1), It.IsAny<CancellationToken>()), Times.Once);
         delayCallCount.ShouldBe(2);
     }
 
@@ -252,8 +260,9 @@ public class RetryBackgroundServiceTests
             IForwardingService forwardingService,
             ISystemClock clock,
             ITimeDelayService timeDelayService,
-            ILogger<RetryBackgroundService> logger)
-            : base(storage, forwardingService, clock, timeDelayService, logger)
+            ILogger<RetryBackgroundService> logger,
+            IConfiguration configuration)
+            : base(storage, forwardingService, clock, timeDelayService, logger, configuration)
         {
         }
         public new Task ExecuteAsync(CancellationToken stoppingToken) => base.ExecuteAsync(stoppingToken);

--- a/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
+++ b/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
@@ -105,6 +105,7 @@ public class RetryBackgroundServiceTests
         return new FailedRequest(
             Id: Guid.NewGuid(),
             Rule: rule,
+            RequestHostUrl: "http://localhost:5000",
             FirstAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
             LastAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
             AttemptCount: 1,

--- a/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
+++ b/http-forwarder-unit-tests/Services/RetryBackgroundServiceTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using http_forwarder_app.Models;
 using http_forwarder_app.Services;
 using OneOf;
+using Shouldly;
 
 namespace http_forwarder_unit_tests;
 
@@ -15,34 +16,40 @@ public class RetryBackgroundServiceTests
     private readonly Mock<IFailedRequestStorage> _storageMock;
     private readonly Mock<IForwardingService> _forwardingServiceMock;
     private readonly Mock<ISystemClock> _clockMock;
+    private readonly Mock<ITimeDelayService> _delayServiceMock;
     private readonly Mock<ILogger<RetryBackgroundService>> _loggerMock;
-    private readonly RetryBackgroundService _service;
+    private readonly TestableRetryBackgroundService _service;
     private readonly CancellationTokenSource _cts;
+    private readonly DateTimeOffset _startTime;
+
 
     public RetryBackgroundServiceTests()
     {
         _storageMock = new Mock<IFailedRequestStorage>();
         _forwardingServiceMock = new Mock<IForwardingService>();
         _clockMock = new Mock<ISystemClock>();
+        _delayServiceMock = new Mock<ITimeDelayService>();
         _loggerMock = new Mock<ILogger<RetryBackgroundService>>();
         _cts = new CancellationTokenSource();
+        _startTime = DateTimeOffset.UtcNow;
 
-        var currentTime = DateTimeOffset.UtcNow;
-        _clockMock.Setup(x => x.UtcNow).Returns(currentTime);
 
-        _service = new RetryBackgroundService(
+        _clockMock.Setup(x => x.UtcNow).Returns(_startTime);
+
+        _service = new TestableRetryBackgroundService(
             _storageMock.Object,
             _forwardingServiceMock.Object,
             _clockMock.Object,
+            _delayServiceMock.Object,
             _loggerMock.Object);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldRetryFailedRequests()
+    public async Task ProcessPendingAsync_ShouldRetryFailedRequestsAndRemoveOnSuccess()
     {
         // Arrange
         var request = CreateTestRequest();
-        _storageMock.Setup(x => x.GetPendingRequests())
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
             .Returns(new List<FailedRequest> { request });
 
         var successResult = new HttpResponseRuleResult(
@@ -57,18 +64,19 @@ public class RetryBackgroundServiceTests
 
         // Act
         _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
-        await _service.StartAsync(_cts.Token);
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
 
         // Assert
         _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldUpdateRetryInfoOnFailure()
+    public async Task ProcessPendingAsync_ShouldUpdateRetryInfoOnServerErrorFailure()
     {
         // Arrange
         var request = CreateTestRequest();
-        _storageMock.Setup(x => x.GetPendingRequests())
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
             .Returns(new List<FailedRequest> { request });
 
         var failureResult = new HttpResponseRuleResult(
@@ -83,13 +91,136 @@ public class RetryBackgroundServiceTests
 
         // Act
         _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
-        await _service.StartAsync(_cts.Token);
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
 
         // Assert
         _storageMock.Verify(x => x.Store(It.Is<FailedRequest>(r =>
             r.Id == request.Id &&
             r.AttemptCount == request.AttemptCount + 1)),
             Times.Once);
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Never);
+    }
+
+
+    [Fact]
+    public async Task ProcessPendingAsync_ShouldUpdateRetryInfoOnClientErrorFailure()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
+            .Returns(new List<FailedRequest> { request });
+
+        var failureResult = new HttpResponseRuleResult(
+            new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest),
+            request.Rule);
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(failureResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoRequests_ShouldWaitAndLoop()
+    {
+        // Arrange
+        _storageMock.Setup(s => s.GetAllRequests()).Returns([]);
+        _storageMock.Setup(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>())).Returns([]);
+        _storageMock.Setup(s => s.StorageHash).Returns(1);
+
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+            .Callback(() => _cts.Cancel()) // Cancel on first delay to exit loop
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.ExecuteAsync(_cts.Token);
+
+        // Assert
+        _storageMock.Verify(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>()), Times.Once);
+        _storageMock.Verify(s => s.GetAllRequests(), Times.Once);
+        _storageMock.Verify(x => x.Remove(It.IsAny<Guid>()), Times.Never);
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Once);
+        _forwardingServiceMock.Verify(f => f.ProcessPostEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRequestsAreDue_ShouldProcessThem()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>())).Returns([request]);
+        _storageMock.Setup(s => s.GetAllRequests()).Returns([]); // No more requests after processing
+        _storageMock.Setup(s => s.StorageHash).Returns(1);
+
+        var successResult = new HttpResponseRuleResult(new(System.Net.HttpStatusCode.OK), request.Rule);
+        _forwardingServiceMock.Setup(f => f.ProcessPostEvent(request.Rule.Event, request.RequestHostUrl, request.Rule.Content!))
+            .ReturnsAsync(successResult);
+
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+            .Callback(() => _cts.Cancel())
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.ExecuteAsync(_cts.Token);
+
+        // Assert
+        _storageMock.Verify(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>()), Times.Once);
+        _forwardingServiceMock.Verify(f => f.ProcessPostEvent(request.Rule.Event, request.RequestHostUrl, request.Rule.Content!), Times.Once);
+        _storageMock.Verify(s => s.Remove(request.Id), Times.Once);
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStorageChanges_ShouldReEvaluate()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        var nextAttemptTime = _startTime.AddMinutes(10);
+        var requestInFuture = request with { NextAttempt = nextAttemptTime };
+
+        var storageHash = 1;
+        _storageMock.Setup(s => s.StorageHash).Returns(() => storageHash);
+        _storageMock.SetupSequence(s => s.GetAllRequests())
+            .Returns([]) // First call, no requests
+            .Returns([requestInFuture]); // Second call, after hash change
+
+        _storageMock.Setup(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>())).Returns([]);
+
+        int delayCallCount = 0;
+        _delayServiceMock.Setup(d => d.DelayAsync(It.IsAny<TimeSpan>(), _cts.Token))
+            .Callback<TimeSpan, CancellationToken>((delay, token) =>
+            {
+                delayCallCount++;
+                if (delayCallCount == 1)
+                {
+                    // After first loop, simulate storage change
+                    storageHash = 2;
+                }
+                else
+                {
+                    _cts.Cancel();
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.ExecuteAsync(_cts.Token);
+
+        // Assert
+        _storageMock.Verify(s => s.GetRequestsDue(It.IsAny<DateTimeOffset>()), Times.Exactly(2));
+        _storageMock.Verify(s => s.GetAllRequests(), Times.Exactly(2));
+        _delayServiceMock.Verify(d => d.DelayAsync(TimeSpan.FromSeconds(30), _cts.Token), Times.Exactly(2));
+        delayCallCount.ShouldBe(2);
     }
 
     private FailedRequest CreateTestRequest()
@@ -106,10 +237,102 @@ public class RetryBackgroundServiceTests
             Id: Guid.NewGuid(),
             Rule: rule,
             RequestHostUrl: "http://localhost:5000",
-            FirstAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
-            LastAttempt: _clockMock.Object.UtcNow.AddMinutes(-5),
+            FirstAttempt: _startTime.AddMinutes(-5),
+            LastAttempt: _startTime.AddMinutes(-5),
             AttemptCount: 1,
-            NextAttempt: _clockMock.Object.UtcNow.AddMinutes(-1),
+            NextAttempt: _startTime.AddMinutes(-1),
             LastError: "test error");
+    }
+
+    // Helper class to expose ExecuteAsync for testing
+    private class TestableRetryBackgroundService : RetryBackgroundService
+    {
+        public TestableRetryBackgroundService(
+            IFailedRequestStorage storage,
+            IForwardingService forwardingService,
+            ISystemClock clock,
+            ITimeDelayService timeDelayService,
+            ILogger<RetryBackgroundService> logger)
+            : base(storage, forwardingService, clock, timeDelayService, logger)
+        {
+        }
+        public new Task ExecuteAsync(CancellationToken stoppingToken) => base.ExecuteAsync(stoppingToken);
+
+        public new Task ProcessPendingAsync(DateTimeOffset asOf, CancellationToken stoppingToken) => base.ProcessPendingAsync(asOf, stoppingToken);
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_ShouldRemoveRequestOnNoRuleFound()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
+            .Returns(new List<FailedRequest> { request });
+
+        NoMatchingRuleResult noRuleResult = new();
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(noRuleResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_ShouldRemoveRequestOnNoBody()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
+            .Returns(new List<FailedRequest> { request });
+
+        NoBodyRuleResult noBodyResult = new();
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(noBodyResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_ShouldRemoveRequestOnRemoteRule()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+        _storageMock.Setup(x => x.GetRequestsDue(It.IsAny<DateTimeOffset>()))
+            .Returns(new List<FailedRequest> { request });
+
+        RemoteRuleFoundResult remoteRuleResult = new(request.Rule);
+
+        _forwardingServiceMock.Setup(x => x.ProcessPostEvent(
+            request.Rule.Event,
+            It.IsAny<string>(),
+            request.Rule.Content!))
+            .ReturnsAsync(remoteRuleResult);
+
+        // Act
+        _cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessPendingAsync(_startTime.AddSeconds(1), _cts.Token);
+
+        // Assert
+        _storageMock.Verify(x => x.Store(It.IsAny<FailedRequest>()), Times.Never);
+        _storageMock.Verify(x => x.Remove(request.Id), Times.Once);
     }
 }

--- a/http-forwarder-unit-tests/http-forwarder-unit-tests.csproj
+++ b/http-forwarder-unit-tests/http-forwarder-unit-tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../http-forwarder-app-function/http-forwarder-app-function.csproj" />
+    <ProjectReference Include="../http-forwarder-app/http-forwarder-app.csproj" />
     <ProjectReference Include="../http-forwarder-utils/http-forwarder-utils.csproj" />
     <ProjectReference Include="../http-forwarder-models/http-forwarder-models.csproj" />
   </ItemGroup>

--- a/http-forwarder-utils/ConfigurationUtils.cs
+++ b/http-forwarder-utils/ConfigurationUtils.cs
@@ -54,4 +54,14 @@ public static class ConfigurationExtensions
         return configuration.GetValue<string?>(Constants.GENERIC_TOPIC_ALLOWED_EVENTS);
     }
 
+    public static string? GetConfiguredStoragePath(this IConfiguration configuration)
+    {
+        return configuration.GetValue<string?>(Constants.STORAGE_DIR_PATH, null);
+    }
+
+    public static int GetRetryMaxConcurrency(this IConfiguration configuration)
+    {
+        return configuration.GetValue<int>(Constants.RETRY_POLICY_MAX_CONCURRENCY, 4);
+    }
+
 }

--- a/http-forwarder-utils/JsonUtils.cs
+++ b/http-forwarder-utils/JsonUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 
 namespace http_forwarder_app.Core
@@ -12,6 +13,11 @@ namespace http_forwarder_app.Core
         public static T? Deserialize<T>(string json)
         {
             return JsonSerializer.Deserialize<T>(json, CreateJsonSerializerOptions());
+        }
+
+        public static object? Deserialize(string json, Type type)
+        {
+            return JsonSerializer.Deserialize(json, type, CreateJsonSerializerOptions());
         }
 
         public static string Serialize<T>(T item, bool indent)

--- a/http-forwarder-utils/RestUtils.cs
+++ b/http-forwarder-utils/RestUtils.cs
@@ -1,0 +1,14 @@
+using System.Net;
+
+namespace http_forwarder_app.Core;
+
+public static class RestUtils
+{
+    public static bool IsServerError(this HttpResponseMessage response)
+    {
+        return !response.IsSuccessStatusCode && response.StatusCode.IsServerError();
+    }
+
+    public static bool IsServerError(this HttpStatusCode statusCode) =>
+            (int)statusCode >= 500 && (int)statusCode <= 599;
+}


### PR DESCRIPTION
- Add Retry feature. Users can define a new property isRetryable in rules for POST, PUT and DELETE operations that will retry if there is a server error the first time. This feature uses file storage temporarily (up to 24 hours). Users would need to define a storage directory in docker so that the file survives container restarts.
- Add request body support in Swagger
- Add many more tests