### PR TITLE
Enable implicit usings in app project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,8 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Generated analysis artifacts
+ANALYSIS-INDEX.md
+HTTP-FORWARDER-ANALYSIS.md
+HTTP-FORWARDER-SUMMARY.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 ## Style
 - No repo `.editorconfig`, ruleset, or StyleCop config is present; use the existing C# style in touched files.
 - `dotnet format http-forwarder.slnx --verify-no-changes --verbosity minimal` is the available formatting check when style risk is high.
-- Nullable reference types are enabled across projects; most projects also enable implicit usings, but `http-forwarder-app` does not.
+- Nullable reference types and implicit usings are enabled across projects.
 
 ## CI And Containers
 - GitHub Actions uses .NET SDK `10.0`, runs Release build/tests, then builds multi-arch GHCR images with Buildx.

--- a/http-forwarder-app/Controllers/ForwardingController.cs
+++ b/http-forwarder-app/Controllers/ForwardingController.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Globalization;
-using System.IO;
-using System.Threading.Tasks;
 using http_forwarder_app.Core;
 using http_forwarder_app.Models;
 using http_forwarder_app.Services;
 using http_forwarder_app.Utils;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;

--- a/http-forwarder-app/Controllers/PingController.cs
+++ b/http-forwarder-app/Controllers/PingController.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace http_forwarder_app.Controllers;

--- a/http-forwarder-app/Core/ForwardingRulesReader.cs
+++ b/http-forwarder-app/Core/ForwardingRulesReader.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Linq;
 using http_forwarder_app.Models;
 using http_forwarder_app.Utils;
 using Microsoft.Extensions.Configuration;

--- a/http-forwarder-app/Core/IRestClient.cs
+++ b/http-forwarder-app/Core/IRestClient.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
-
 namespace http_forwarder_app.Core
 {
     public interface IRestClient

--- a/http-forwarder-app/Core/PathUtils.cs
+++ b/http-forwarder-app/Core/PathUtils.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 

--- a/http-forwarder-app/Core/ResponseUtils.cs
+++ b/http-forwarder-app/Core/ResponseUtils.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-
 namespace http_forwarder_app
 {
     public static class ResponseUtils

--- a/http-forwarder-app/Core/RestClient.cs
+++ b/http-forwarder-app/Core/RestClient.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using http_forwarder_app.Utils;

--- a/http-forwarder-app/Core/RetryExtensions.cs
+++ b/http-forwarder-app/Core/RetryExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace http_forwarder_app.Extensions;
 
 public static class RetryExtensions

--- a/http-forwarder-app/Formatters/RawRequestBodyFormatter.cs
+++ b/http-forwarder-app/Formatters/RawRequestBodyFormatter.cs
@@ -1,10 +1,6 @@
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
-using Microsoft.AspNetCore.Http;
 using http_forwarder_app.Utils;
 
 namespace http_forwarder_app.Formatters;

--- a/http-forwarder-app/Models/AppState.cs
+++ b/http-forwarder-app/Models/AppState.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-
 namespace http_forwarder_app.Models
 {
     public class AppState

--- a/http-forwarder-app/Program.cs
+++ b/http-forwarder-app/Program.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.RateLimiting;
 using http_forwarder_app;
 using http_forwarder_app.Cloud;
@@ -9,14 +5,7 @@ using http_forwarder_app.Core;
 using http_forwarder_app.Models;
 using http_forwarder_app.Models.Services;
 using http_forwarder_app.Services;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.Logging;
-using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
 
 var newArgs = args.ToList();

--- a/http-forwarder-app/Services/BackgroundListeningService.cs
+++ b/http-forwarder-app/Services/BackgroundListeningService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Google.Cloud.PubSub.V1;
 using http_forwarder_app.Core;
 using http_forwarder_app.Models;

--- a/http-forwarder-app/Services/CloudMessageHandler.cs
+++ b/http-forwarder-app/Services/CloudMessageHandler.cs
@@ -1,10 +1,6 @@
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Google.Cloud.PubSub.V1;
 using http_forwarder_app.Models;
 using http_forwarder_app.Utils;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using OneOf;
 

--- a/http-forwarder-app/Services/CloudMessageHandlerFactory.cs
+++ b/http-forwarder-app/Services/CloudMessageHandlerFactory.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using http_forwarder_app.Models;
 using Microsoft.Extensions.Logging;
 

--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Internal;
 using http_forwarder_app.Models;

--- a/http-forwarder-app/Services/ForwardingService.cs
+++ b/http-forwarder-app/Services/ForwardingService.cs
@@ -3,10 +3,6 @@ using http_forwarder_app.Models;
 using http_forwarder_app.Utils;
 using Microsoft.Extensions.Logging;
 using OneOf;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
 
 namespace http_forwarder_app.Services;
 

--- a/http-forwarder-app/Services/RemoteRulePublishingService.cs
+++ b/http-forwarder-app/Services/RemoteRulePublishingService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using http_forwarder_app.Core;
 using http_forwarder_app.Models;
 using http_forwarder_app.Models.Services;

--- a/http-forwarder-app/Services/RetryBackgroundService.cs
+++ b/http-forwarder-app/Services/RetryBackgroundService.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Internal;
 using http_forwarder_app.Models;

--- a/http-forwarder-app/Services/TimeDelayService.cs
+++ b/http-forwarder-app/Services/TimeDelayService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using http_forwarder_app.Models;
 
 namespace http_forwarder_app.Services;

--- a/http-forwarder-app/VersionUtils.cs
+++ b/http-forwarder-app/VersionUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 using http_forwarder_app.Utils;
 using Semver;
 

--- a/http-forwarder-app/http-forwarder-app.csproj
+++ b/http-forwarder-app/http-forwarder-app.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>http_forwarder_app</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable implicit usings for `http-forwarder-app`
- remove redundant using directives from app project source files
- update `AGENTS.md` style guidance
- ignore generated analysis artifacts to avoid accidental commits

## Verification
- dotnet test "http-forwarder.slnx"
- git diff --check