### PR TITLE
Update GHCR cleanup action

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -15,7 +15,7 @@ jobs:
       
     steps:
       - name: Apply container retention policy
-        uses: snok/container-retention-policy@v3.0.0
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update snok/container-retention-policy from v3.0.0 to v3.1.0 in the GHCR cleanup workflow
- v3.1.0 release notes mention a fix for GitHub token format migration parsing, which matches the failed scheduled cleanup run

## Context
- Failed run: https://github.com/ankitmehtame/http-forwarder/actions/runs/26739861256
- Upstream release: https://github.com/snok/container-retention-policy/releases/tag/v3.1.0

## Testing
- Not run; workflow-only action version bump