### PR TITLE
Require API key authentication for the cloud function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Project Shape
 - Main ASP.NET Core app entrypoint is `http-forwarder-app/Program.cs`; forwarding routes are in `http-forwarder-app/Controllers/ForwardingController.cs` under `/forward/{eventName}` and `/api/forward/{eventName}`.
-- Cloud Function entrypoint is `http-forwarder-app-function/Function.cs`; it only accepts `POST`/`PUT` and filters events with `ALLOWED_EVENTS`.
+- Cloud Function entrypoint is `http-forwarder-app-function/Function.cs`; it only accepts `POST`/`PUT`, requires an API key (`X-API-Key` header or `apiKey` query) from `ALLOWED_API_KEYS`, and filters events with `ALLOWED_EVENTS`.
 - Shared DTOs/rules live in `http-forwarder-models`; config/path helpers live in `http-forwarder-utils`; Pub/Sub publishing lives in `http-forwarder-cloud`.
 - Package versions are centrally managed in `Directory.Packages.props`; keep versions out of individual `.csproj` `PackageReference`s.
 - Version stamping uses Nerdbank.GitVersioning from `Directory.Build.props` and `version.json`; Docker builds receive NBGV values from CI build args.

--- a/Dockerfile.cloudfunction
+++ b/Dockerfile.cloudfunction
@@ -22,5 +22,9 @@ WORKDIR /app
 COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "http-forwarder-app-function.dll"]
 
+# Functions Framework binds via PORT + UseKestrel/Listen. Clear the aspnet
+# image hosting URL defaults so Kestrel does not warn about overriding them.
 ENV PORT=8080
+ENV ASPNETCORE_URLS=
+ENV ASPNETCORE_HTTP_PORTS=
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The application is configured through environment variables. Most routing is don
 - `RATE_LIMITING_ENABLED` — Enable per-client-IP rate limiting (default: `true`).
 - `RATE_LIMIT_PER_WINDOW` — Number of requests allowed for each client IP in one window (default: `60`).
 - `RATE_LIMIT_WINDOW_SECONDS` — Rate limit window size in seconds (default: `60`).
+- `ALLOWED_API_KEYS` — **Required for the Cloud Function**. Comma-separated list of accepted API keys. Callers must send a matching key via the `X-API-Key` header or `apiKey` query parameter; otherwise the function returns `401 Unauthorized`. The API key is not republished to Pub/Sub.
 
 Rate limiting uses the first IP in `X-Forwarded-For` when present, then falls back to the connection remote IP. Requests over the configured limit return `429 Too Many Requests` with a `Retry-After` header. This is not an allowlist or authentication mechanism; it only limits request volume.
 

--- a/http-forwarder-app-function/Function.cs
+++ b/http-forwarder-app-function/Function.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Google.Apis.Util;
 using Google.Cloud.Functions.Framework;
@@ -144,7 +143,7 @@ public class Function : IHttpFunction
         }
 
         // Strip API key header so it is not republished to Pub/Sub
-        var requestHeaders = StripApiKeyHeader(context.Request.Headers.GetHeaders());
+        var requestHeaders = context.Request.Headers.GetHeaders(additionalIgnoredHeaders: [ApiKeyHeaderName]);
 
         ForwardingRequest fwdRequest = new(
             Method: requestMethod,
@@ -207,13 +206,6 @@ public class Function : IHttpFunction
 
         return (hasHeaderKey && _allowedApiKeys.Contains(headerApiKey!))
             || (hasQueryKey && _allowedApiKeys.Contains(queryApiKey!));
-    }
-
-    private static ImmutableSortedDictionary<string, string> StripApiKeyHeader(ImmutableSortedDictionary<string, string> headers)
-    {
-        return headers
-            .Where(kvp => !string.Equals(kvp.Key, ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
-            .ToImmutableSortedDictionary();
     }
 
     private bool TryConsumeRateLimit(HttpContext context)

--- a/http-forwarder-app-function/Function.cs
+++ b/http-forwarder-app-function/Function.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Google.Apis.Util;
 using Google.Cloud.Functions.Framework;
@@ -21,6 +22,7 @@ public class Function : IHttpFunction
     private readonly string _topicId;
 
     private readonly HashSet<string> _allowedEvents;
+    private readonly HashSet<string> _allowedApiKeys;
     private readonly TimeSpan _regexMatchTimeout;
     private readonly bool _rateLimitingEnabled;
     private readonly int _rateLimitPerWindow;
@@ -28,6 +30,8 @@ public class Function : IHttpFunction
     private static long InstantiationCounter = 0;
     private static readonly ConcurrentDictionary<string, RateLimitWindow> RateLimitWindows = new();
     private readonly IPublishingService _publishingService;
+    private const string ApiKeyHeaderName = "X-API-Key";
+    private const string ApiKeyQueryParameterName = "apiKey";
 
     public Function(ILogger<Function> logger, IConfiguration configuration, IPublishingService publishingService)
     {
@@ -52,6 +56,26 @@ public class Function : IHttpFunction
             _allowedEvents = allowedEvents
                                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var allowedApiKeys = configuration.GetAllowedApiKeys() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(allowedApiKeys))
+            {
+                _logger.LogError("Environment variable '{AllowedApiKeysEnvVar}' is not set.", Constants.ALLOWED_API_KEYS);
+                throw new InvalidOperationException($"Environment variable '{Constants.ALLOWED_API_KEYS}' is not set.");
+            }
+            _allowedApiKeys = allowedApiKeys
+                                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                .ToHashSet(StringComparer.Ordinal);
+            if (_allowedApiKeys.Count == 0)
+            {
+                _logger.LogError("Environment variable '{AllowedApiKeysEnvVar}' does not contain any API keys.", Constants.ALLOWED_API_KEYS);
+                throw new InvalidOperationException($"Environment variable '{Constants.ALLOWED_API_KEYS}' does not contain any API keys.");
+            }
+            if (isFirstTime)
+            {
+                _logger.LogInformation("Configured {allowedApiKeyCount} API key(s)", _allowedApiKeys.Count);
+            }
+
             _regexMatchTimeout = configuration.GetRegexMatchTimeout();
             _rateLimitingEnabled = configuration.IsRateLimitingEnabled();
             _rateLimitPerWindow = configuration.GetRateLimitPerWindow();
@@ -89,6 +113,13 @@ public class Function : IHttpFunction
             return;
         }
 
+        if (!TryAuthorizeApiKey(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized");
+            return;
+        }
+
         var eventName = GetEventName(requestPath);
         _logger.LogInformation("Event is {eventName}", eventName);
         if (string.IsNullOrEmpty(eventName))
@@ -112,7 +143,8 @@ public class Function : IHttpFunction
             requestBody = ((await reader.ReadToEndAsync()) ?? string.Empty).Trim();
         }
 
-        var requestHeaders = context.Request.Headers.GetHeaders();
+        // Strip API key header so it is not republished to Pub/Sub
+        var requestHeaders = StripApiKeyHeader(context.Request.Headers.GetHeaders());
 
         ForwardingRequest fwdRequest = new(
             Method: requestMethod,
@@ -155,6 +187,33 @@ public class Function : IHttpFunction
             return eventName;
         }
         return string.Empty;
+    }
+
+    private bool TryAuthorizeApiKey(HttpContext context)
+    {
+        var headerApiKey = context.Request.Headers[ApiKeyHeaderName].FirstOrDefault();
+        var queryApiKey = context.Request.Query[ApiKeyQueryParameterName].FirstOrDefault();
+
+        var hasHeaderKey = !string.IsNullOrEmpty(headerApiKey);
+        var hasQueryKey = !string.IsNullOrEmpty(queryApiKey);
+
+        if (hasHeaderKey && hasQueryKey)
+        {
+            _logger.LogWarning(
+                "Multiple API keys were provided via both {ApiKeyHeaderName} header and {ApiKeyQueryParameterName} query parameter; this is likely a mistake",
+                ApiKeyHeaderName,
+                ApiKeyQueryParameterName);
+        }
+
+        return (hasHeaderKey && _allowedApiKeys.Contains(headerApiKey!))
+            || (hasQueryKey && _allowedApiKeys.Contains(queryApiKey!));
+    }
+
+    private static ImmutableSortedDictionary<string, string> StripApiKeyHeader(ImmutableSortedDictionary<string, string> headers)
+    {
+        return headers
+            .Where(kvp => !string.Equals(kvp.Key, ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
+            .ToImmutableSortedDictionary();
     }
 
     private bool TryConsumeRateLimit(HttpContext context)

--- a/http-forwarder-models/Constants.cs
+++ b/http-forwarder-models/Constants.cs
@@ -22,6 +22,8 @@ public static class Constants
 
     public const string GENERIC_TOPIC_ALLOWED_EVENTS = "ALLOWED_EVENTS";
 
+    public const string ALLOWED_API_KEYS = "ALLOWED_API_KEYS";
+
     public const string STORAGE_DIR_PATH = "STORAGE_DIR_PATH";
 
     public const string RETRY_POLICY_MAX_CONCURRENCY = "RETRY_POLICY_MAX_CONCURRENCY";

--- a/http-forwarder-unit-tests/CloudFunctionTests.cs
+++ b/http-forwarder-unit-tests/CloudFunctionTests.cs
@@ -9,6 +9,7 @@ using http_forwarder_app.Models.Services;
 using http_forwarder_app.Models;
 using http_forwarder_app.Utils;
 using System.Collections.Immutable;
+using http_forwarder_app;
 
 namespace http_forwarder_unit_tests;
 
@@ -17,6 +18,7 @@ public class FunctionUnitTests
     const string projectId = "test-project-id";
     const string topicId = "test-topic-id";
     const string eventName = "user-registered";
+    const string validApiKey = "test-api-key";
 
     [Theory]
     [InlineData("xyz, user-registered", "POST")]
@@ -27,11 +29,7 @@ public class FunctionUnitTests
     public async Task HandleAsync_ValidRequest_PublishesMessageAndReturnsOk(string allowedEvents, string requestMethod)
     {
         // Arrange
-        var inMemorySettings = new Dictionary<string, string?> {
-            {"ALLOWED_EVENTS", allowedEvents},
-            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
-            {"PUBSUB_TOPIC_ID", topicId},
-        };
+        var inMemorySettings = CreateDefaultSettings(allowedEvents);
 
         var setupData = Setup(requestMethod: requestMethod, inMemorySettings: inMemorySettings);
 
@@ -55,11 +53,7 @@ public class FunctionUnitTests
     public async Task HandleAsync_PostRequest_NotAllowedEvent_ReturnsNok()
     {
         // Arrange
-        var inMemorySettings = new Dictionary<string, string?> {
-            {"ALLOWED_EVENTS", "xyz, not-user-registered"},
-            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
-            {"PUBSUB_TOPIC_ID", topicId},
-        };
+        var inMemorySettings = CreateDefaultSettings("xyz, not-user-registered");
         const string requestMethod = "POST";
         var setupData = Setup(requestMethod: requestMethod, inMemorySettings: inMemorySettings);
 
@@ -81,11 +75,7 @@ public class FunctionUnitTests
     public async Task HandleAsync_InvalidAllowedEventRegex_ReturnsNok()
     {
         // Arrange
-        var inMemorySettings = new Dictionary<string, string?> {
-            {"ALLOWED_EVENTS", "["},
-            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
-            {"PUBSUB_TOPIC_ID", topicId},
-        };
+        var inMemorySettings = CreateDefaultSettings("[");
         const string requestMethod = "POST";
         var setupData = Setup(requestMethod: requestMethod, inMemorySettings: inMemorySettings);
 
@@ -103,14 +93,10 @@ public class FunctionUnitTests
     public async Task HandleAsync_WhenRateLimitExceeded_ReturnsTooManyRequests()
     {
         // Arrange
-        var inMemorySettings = new Dictionary<string, string?> {
-            {"ALLOWED_EVENTS", "user-registered"},
-            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
-            {"PUBSUB_TOPIC_ID", topicId},
-            {"RATE_LIMITING_ENABLED", "true"},
-            {"RATE_LIMIT_PER_WINDOW", "1"},
-            {"RATE_LIMIT_WINDOW_SECONDS", "60"}
-        };
+        var inMemorySettings = CreateDefaultSettings("user-registered");
+        inMemorySettings["RATE_LIMITING_ENABLED"] = "true";
+        inMemorySettings["RATE_LIMIT_PER_WINDOW"] = "1";
+        inMemorySettings["RATE_LIMIT_WINDOW_SECONDS"] = "60";
         const string requestMethod = "POST";
         const string clientIp = "198.51.100.77";
         var firstSetupData = Setup(requestMethod: requestMethod, inMemorySettings: inMemorySettings, clientIp: clientIp);
@@ -135,11 +121,7 @@ public class FunctionUnitTests
     public async Task HandleAsync_MethodRequest_ReturnsNok(string requestMethod)
     {
         // Arrange
-        var inMemorySettings = new Dictionary<string, string?> {
-            {"ALLOWED_EVENTS", "xyz, user-registered"},
-            {"GOOGLE_CLOUD_PROJECT_ID", "test-project-id"},
-            {"PUBSUB_TOPIC_ID", "test-topic-id"},
-        };
+        var inMemorySettings = CreateDefaultSettings("xyz, user-registered");
         var setupData = Setup(requestMethod: requestMethod, inMemorySettings: inMemorySettings);
 
         var function = new http_forwarder_app.Functions.Function(setupData.MockLogger.Object, setupData.Configuration, setupData.MockPublishingService.Object);
@@ -154,6 +136,114 @@ public class FunctionUnitTests
         // Verify the content of the HTTP response body from the function
         var responseBody = await GetResponseContent(setupData);
         responseBody.ShouldContain("Not allowed");
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingApiKey_ReturnsUnauthorized()
+    {
+        // Arrange
+        var inMemorySettings = CreateDefaultSettings("user-registered");
+        var setupData = Setup(requestMethod: "POST", inMemorySettings: inMemorySettings, apiKeyHeader: null, apiKeyQuery: null);
+
+        var function = new http_forwarder_app.Functions.Function(setupData.MockLogger.Object, setupData.Configuration, setupData.MockPublishingService.Object);
+
+        // Act
+        await function.HandleAsync(setupData.HttpContext);
+
+        // Assert
+        setupData.RespFeature.StatusCode.ShouldBe((int)HttpStatusCode.Unauthorized);
+        setupData.MockPublishingService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ForwardingRequest>()), Times.Never);
+        var responseBody = await GetResponseContent(setupData);
+        responseBody.ShouldContain("Unauthorized");
+    }
+
+    [Fact]
+    public async Task HandleAsync_InvalidApiKey_ReturnsUnauthorized()
+    {
+        // Arrange
+        var inMemorySettings = CreateDefaultSettings("user-registered");
+        var setupData = Setup(requestMethod: "POST", inMemorySettings: inMemorySettings, apiKeyHeader: "wrong-key");
+
+        var function = new http_forwarder_app.Functions.Function(setupData.MockLogger.Object, setupData.Configuration, setupData.MockPublishingService.Object);
+
+        // Act
+        await function.HandleAsync(setupData.HttpContext);
+
+        // Assert
+        setupData.RespFeature.StatusCode.ShouldBe((int)HttpStatusCode.Unauthorized);
+        setupData.MockPublishingService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ForwardingRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidApiKeyInQuery_PublishesMessageAndReturnsOk()
+    {
+        // Arrange
+        var inMemorySettings = CreateDefaultSettings("user-registered");
+        var setupData = Setup(requestMethod: "POST", inMemorySettings: inMemorySettings, apiKeyHeader: null, apiKeyQuery: validApiKey);
+
+        var function = new http_forwarder_app.Functions.Function(setupData.MockLogger.Object, setupData.Configuration, setupData.MockPublishingService.Object);
+
+        // Act
+        await function.HandleAsync(setupData.HttpContext);
+
+        // Assert
+        setupData.RespFeature.StatusCode.ShouldBe((int)HttpStatusCode.OK);
+        setupData.MockPublishingService.Verify(x => x.Publish(projectId, topicId, It.IsAny<ForwardingRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_BothApiKeysProvided_OneValid_PublishesWithoutApiKeyHeader()
+    {
+        // Arrange
+        var inMemorySettings = CreateDefaultSettings("user-registered");
+        var setupData = Setup(
+            requestMethod: "POST",
+            inMemorySettings: inMemorySettings,
+            apiKeyHeader: validApiKey,
+            apiKeyQuery: "other-key");
+
+        var function = new http_forwarder_app.Functions.Function(setupData.MockLogger.Object, setupData.Configuration, setupData.MockPublishingService.Object);
+
+        // Act
+        await function.HandleAsync(setupData.HttpContext);
+
+        // Assert
+        setupData.RespFeature.StatusCode.ShouldBe((int)HttpStatusCode.OK);
+        setupData.MockPublishingService.Verify(
+            x => x.Publish(
+                projectId,
+                topicId,
+                It.Is<ForwardingRequest>(r =>
+                    r.Event == eventName
+                    && !r.RequestHeaders.Keys.Any(k => string.Equals(k, "X-API-Key", StringComparison.OrdinalIgnoreCase)))),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",,,")]
+    public void Constructor_WhenAllowedApiKeysMissingOrEmpty_Throws(string? allowedApiKeys)
+    {
+        // Arrange
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            {"ALLOWED_EVENTS", "user-registered"},
+            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
+            {"PUBSUB_TOPIC_ID", topicId},
+            {"ALLOWED_API_KEYS", allowedApiKeys},
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+        var mockLogger = new Mock<ILogger<http_forwarder_app.Functions.Function>>();
+        var mockPublishingService = new Mock<IPublishingService>();
+
+        // Act & Assert
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            new http_forwarder_app.Functions.Function(mockLogger.Object, configuration, mockPublishingService.Object));
+        ex.Message.ShouldContain(Constants.ALLOWED_API_KEYS);
     }
 
     [Fact]
@@ -182,7 +272,23 @@ public class FunctionUnitTests
         (req2 == req1).ShouldBeTrue();
     }
 
-    private static SetupData Setup(string requestMethod, IDictionary<string, string?> inMemorySettings, string? clientIp = null)
+    private static Dictionary<string, string?> CreateDefaultSettings(string allowedEvents)
+    {
+        return new Dictionary<string, string?>
+        {
+            {"ALLOWED_EVENTS", allowedEvents},
+            {"GOOGLE_CLOUD_PROJECT_ID", projectId},
+            {"PUBSUB_TOPIC_ID", topicId},
+            {"ALLOWED_API_KEYS", validApiKey},
+        };
+    }
+
+    private static SetupData Setup(
+        string requestMethod,
+        IDictionary<string, string?> inMemorySettings,
+        string? clientIp = null,
+        string? apiKeyHeader = validApiKey,
+        string? apiKeyQuery = null)
     {
         var mockLogger = new Mock<ILogger<http_forwarder_app.Functions.Function>>();
         var mockPublishingService = new Mock<IPublishingService>();
@@ -194,6 +300,10 @@ public class FunctionUnitTests
         if (!string.IsNullOrWhiteSpace(clientIp))
         {
             headers["X-Forwarded-For"] = clientIp;
+        }
+        if (!string.IsNullOrEmpty(apiKeyHeader))
+        {
+            headers["X-API-Key"] = apiKeyHeader;
         }
         var requestBodyStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(jsonContent));
 
@@ -211,6 +321,10 @@ public class FunctionUnitTests
         reqFeature.Body = requestBodyStream;
         reqFeature.Headers = new HeaderDictionary();
         headers.ToList().ForEach(x => reqFeature.Headers.Append(x.Key, x.Value));
+        if (!string.IsNullOrEmpty(apiKeyQuery))
+        {
+            reqFeature.QueryString = $"?apiKey={Uri.EscapeDataString(apiKeyQuery)}";
+        }
         httpContext.Features.Set(reqFeature);
 
         httpContext.Features.Set(respFeature);
@@ -218,11 +332,16 @@ public class FunctionUnitTests
         var responseBodyFeature = new StreamResponseBodyFeature(responseBodyStream);
         httpContext.Features.Set<IHttpResponseBodyFeature>(responseBodyFeature);
 
+        // Published payload must not include the API key header
+        var publishedHeaders = headers
+            .Where(kvp => !string.Equals(kvp.Key, "X-API-Key", StringComparison.OrdinalIgnoreCase))
+            .ToImmutableSortedDictionary();
+
         ForwardingRequest fwdRequest = new(
             Event: eventName,
             Method: requestMethod,
             Content: jsonContent,
-            RequestHeaders: headers.ToImmutableSortedDictionary());
+            RequestHeaders: publishedHeaders);
 
         mockPublishingService
             .Setup(ps => ps.Publish(projectId, topicId, It.Is<ForwardingRequest>(r => r == fwdRequest)))

--- a/http-forwarder-utils/ConfigurationUtils.cs
+++ b/http-forwarder-utils/ConfigurationUtils.cs
@@ -106,6 +106,11 @@ public static class ConfigurationExtensions
         return configuration.GetValue<string?>(Constants.GENERIC_TOPIC_ALLOWED_EVENTS);
     }
 
+    public static string? GetAllowedApiKeys(this IConfiguration configuration)
+    {
+        return configuration.GetValue<string?>(Constants.ALLOWED_API_KEYS);
+    }
+
     public static string? GetConfiguredStoragePath(this IConfiguration configuration)
     {
         return configuration.GetValue<string?>(Constants.STORAGE_DIR_PATH, null);

--- a/http-forwarder-utils/RestUtils.cs
+++ b/http-forwarder-utils/RestUtils.cs
@@ -17,14 +17,34 @@ public static class RestUtils
     public static bool IsServerError(this HttpStatusCode statusCode) =>
             (int)statusCode >= 500 && (int)statusCode <= 599;
 
-    private static readonly HashSet<string> IgnoredHeaders = ["Content-Length", "Host"];
-
-    public static ImmutableSortedDictionary<string, string> GetHeaders(this IHeaderDictionary? requestHeaders)
+    private static readonly HashSet<string> IgnoredHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
+        "Content-Length",
+        "Host"
+    };
+
+    public static ImmutableSortedDictionary<string, string> GetHeaders(
+        this IHeaderDictionary? requestHeaders,
+        IEnumerable<string>? additionalIgnoredHeaders = null)
+    {
+        HashSet<string>? ignoredHeaders = null;
+        if (additionalIgnoredHeaders is not null)
+        {
+            ignoredHeaders = new HashSet<string>(IgnoredHeaders, StringComparer.OrdinalIgnoreCase);
+            foreach (var header in additionalIgnoredHeaders)
+            {
+                if (!string.IsNullOrWhiteSpace(header))
+                {
+                    ignoredHeaders.Add(header);
+                }
+            }
+        }
+
+        var headersToIgnore = ignoredHeaders ?? IgnoredHeaders;
         Dictionary<string, string> requiredHeaders = [];
         foreach (var requiredHeader in requestHeaders ?? Enumerable.Empty<KeyValuePair<string, StringValues>>())
         {
-            if (IgnoredHeaders.Contains(requiredHeader.Key)) continue;
+            if (headersToIgnore.Contains(requiredHeader.Key)) continue;
             requiredHeaders.Add(requiredHeader.Key, string.Join("\n", requiredHeader.Value.ToArray()));
         }
         return requiredHeaders.ToImmutableSortedDictionary();

--- a/http-forwarder-utils/RestUtils.cs
+++ b/http-forwarder-utils/RestUtils.cs
@@ -23,17 +23,34 @@ public static class RestUtils
         "Host"
     };
 
+    private static readonly HashSet<string> EmptyAdditionalIgnoredHeaders = new(StringComparer.OrdinalIgnoreCase);
+
     public static ImmutableSortedDictionary<string, string> GetHeaders(
         this IHeaderDictionary? requestHeaders,
         IEnumerable<string>? additionalIgnoredHeaders = null)
     {
+        var additionalIgnored = EmptyAdditionalIgnoredHeaders;
+        if (additionalIgnoredHeaders is not null)
+        {
+            var additionalIgnoredSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in additionalIgnoredHeaders)
+            {
+                if (!string.IsNullOrWhiteSpace(header))
+                {
+                    additionalIgnoredSet.Add(header);
+                }
+            }
+
+            if (additionalIgnoredSet.Count > 0)
+            {
+                additionalIgnored = additionalIgnoredSet;
+            }
+        }
+
         Dictionary<string, string> requiredHeaders = [];
         foreach (var requiredHeader in requestHeaders ?? Enumerable.Empty<KeyValuePair<string, StringValues>>())
         {
-            if (IgnoredHeaders.Contains(requiredHeader.Key)
-                || (additionalIgnoredHeaders?.Any(header =>
-                    !string.IsNullOrWhiteSpace(header)
-                    && string.Equals(header, requiredHeader.Key, StringComparison.OrdinalIgnoreCase)) ?? false))
+            if (IgnoredHeaders.Contains(requiredHeader.Key) || additionalIgnored.Contains(requiredHeader.Key))
             {
                 continue;
             }

--- a/http-forwarder-utils/RestUtils.cs
+++ b/http-forwarder-utils/RestUtils.cs
@@ -27,24 +27,17 @@ public static class RestUtils
         this IHeaderDictionary? requestHeaders,
         IEnumerable<string>? additionalIgnoredHeaders = null)
     {
-        HashSet<string>? ignoredHeaders = null;
-        if (additionalIgnoredHeaders is not null)
-        {
-            ignoredHeaders = new HashSet<string>(IgnoredHeaders, StringComparer.OrdinalIgnoreCase);
-            foreach (var header in additionalIgnoredHeaders)
-            {
-                if (!string.IsNullOrWhiteSpace(header))
-                {
-                    ignoredHeaders.Add(header);
-                }
-            }
-        }
-
-        var headersToIgnore = ignoredHeaders ?? IgnoredHeaders;
         Dictionary<string, string> requiredHeaders = [];
         foreach (var requiredHeader in requestHeaders ?? Enumerable.Empty<KeyValuePair<string, StringValues>>())
         {
-            if (headersToIgnore.Contains(requiredHeader.Key)) continue;
+            if (IgnoredHeaders.Contains(requiredHeader.Key)
+                || (additionalIgnoredHeaders?.Any(header =>
+                    !string.IsNullOrWhiteSpace(header)
+                    && string.Equals(header, requiredHeader.Key, StringComparison.OrdinalIgnoreCase)) ?? false))
+            {
+                continue;
+            }
+
             requiredHeaders.Add(requiredHeader.Key, string.Join("\n", requiredHeader.Value.ToArray()));
         }
         return requiredHeaders.ToImmutableSortedDictionary();


### PR DESCRIPTION
## Summary
- Require every cloud function request to present a valid API key from `ALLOWED_API_KEYS` via the `X-API-Key` header or `apiKey` query parameter (401 otherwise).
- Fail cloud function startup when `ALLOWED_API_KEYS` is missing or empty; accept either provided key when both are present and warn that supplying both is likely a mistake.
- Strip `X-API-Key` from published Pub/Sub payloads so credentials are not forwarded.

## Test plan
- [x] `dotnet test http-forwarder-unit-tests/http-forwarder-unit-tests.csproj --filter FullyQualifiedName~FunctionUnitTests`
- [ ] Deploy/config check: set `ALLOWED_API_KEYS` on the cloud function and verify missing/invalid keys return 401
- [ ] Verify valid header and query key each allow publish
- [ ] Confirm published Pub/Sub message headers do not include `X-API-Key`


Made with [Cursor](https://cursor.com)