### PR TITLE
Fix forced archive cleanup race

### DIFF
--- a/http-forwarder-app/Services/FailedRequestStorage.cs
+++ b/http-forwarder-app/Services/FailedRequestStorage.cs
@@ -128,7 +128,16 @@ public class FailedRequestStorage : IFailedRequestStorage, IDisposable
 
     public void ScheduleCleanup(bool force)
     {
-        var acquiredLock = Monitor.TryEnter(_archiveLock);
+        var acquiredLock = false;
+        if (force)
+        {
+            Monitor.Enter(_archiveLock);
+            acquiredLock = true;
+        }
+        else
+        {
+            acquiredLock = Monitor.TryEnter(_archiveLock);
+        }
         if (!acquiredLock) return;
         try
         {


### PR DESCRIPTION
## Summary
- Make forced archive cleanup wait for the archive lock.
- Preserve best-effort lock acquisition for background cleanup.

## Fixes
Closes #51

## Testing
- `git diff --check`
- Unable to run `dotnet test` because the environment does not have the `dotnet` CLI installed.