### PR TITLE
Update same-major package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,24 +5,24 @@
 
   <ItemGroup>
     <!-- Core ASP.NET Core packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
 
     <!-- Google Cloud packages -->
-    <PackageVersion Include="Google.Cloud.Functions.Framework" Version="2.0.0" />
-    <PackageVersion Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
-    <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.0.0" />
+    <PackageVersion Include="Google.Cloud.Functions.Framework" Version="2.2.1" />
+    <PackageVersion Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.36.0" />
 
     <!-- Logging packages -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 
     <!-- API documentation -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
 
     <!-- Versioning utilities -->
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.8.118" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="Semver" Version="3.0.0" />
 
     <!-- Error handling -->
@@ -30,15 +30,15 @@
 
     <!-- Testing packages -->
     <PackageVersion Include="Xunit.Repeat" Version="1.1.26" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
 
     <!-- ASP.NET Core testing - separately defined to avoid version conflicts -->
-    <PackageVersion Include="Microsoft.AspNetCore.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Testing" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update centrally managed NuGet dependencies within their existing major versions
- keep major-version upgrades out of scope

## Validation
- `dotnet restore http-forwarder.slnx`
- `dotnet build http-forwarder.slnx --configuration Release --no-restore`
- `dotnet test http-forwarder.slnx --configuration Release --no-build --verbosity normal`
- Docker image: `mcr.microsoft.com/dotnet/sdk:10.0`
- 103 unit tests passed
- 7 acceptance tests passed
- 0 build warnings and 0 errors
- `dotnet list http-forwarder.slnx package --outdated --highest-minor --no-restore` reports no remaining same-major minor updates