### PR TITLE
Add HTTP icon to Swagger UI

### DIFF
--- a/http-forwarder-app/Program.cs
+++ b/http-forwarder-app/Program.cs
@@ -86,11 +86,13 @@ if (app.Environment.IsDevelopment())
     app.UseDeveloperExceptionPage();
 }
 
+app.UseStaticFiles();
 app.UseSwagger();
 app.UseSwaggerUI(c =>
 {
     c.SwaggerEndpoint("/swagger/v1/swagger.json", "Forwarder");
     c.RoutePrefix = string.Empty;
+    c.InjectStylesheet("/swagger-custom.css");
 });
 
 app.UseRouting();

--- a/http-forwarder-app/wwwroot/swagger-custom.css
+++ b/http-forwarder-app/wwwroot/swagger-custom.css
@@ -1,0 +1,5 @@
+.swagger-ui .topbar .link {
+  background: url("/swagger-http.svg") no-repeat left center;
+  background-size: 32px 32px;
+  padding-left: 40px;
+}

--- a/http-forwarder-app/wwwroot/swagger-custom.css
+++ b/http-forwarder-app/wwwroot/swagger-custom.css
@@ -3,3 +3,7 @@
   background-size: 32px 32px;
   padding-left: 40px;
 }
+
+.swagger-ui .topbar .link img {
+  display: none;
+}

--- a/http-forwarder-app/wwwroot/swagger-http.svg
+++ b/http-forwarder-app/wwwroot/swagger-http.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+  <path d="M0 0h24v24H0z" fill="none" />
+  <path fill="#24b42e" d="M14 14v1.17L17.17 12L14 8.83V10H6v4z" opacity=".3" />
+  <path fill="#24b42e" d="m20 12l-8-8v4H4v8h8v4zM6 14v-4h8V8.83L17.17 12L14 15.17V14z" />
+  <text x="8" y="12" fill="#fff" font-size="3.2" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle">http</text>
+</svg>

--- a/http-forwarder-app/wwwroot/swagger-http.svg
+++ b/http-forwarder-app/wwwroot/swagger-http.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
-  <path d="M0 0h24v24H0z" fill="none" />
-  <path fill="#24b42e" d="M14 14v1.17L17.17 12L14 8.83V10H6v4z" opacity=".3" />
-  <path fill="#24b42e" d="m20 12l-8-8v4H4v8h8v4zM6 14v-4h8V8.83L17.17 12L14 15.17V14z" />
-  <text x="8" y="12" fill="#fff" font-size="3.2" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle">http</text>
+	<path d="M0 0h24v24H0z" fill="none" />
+	<path fill="#24b42e" d="M14 14v1.17L17.17 12L14 8.83V10H6v4z" opacity=".3" />
+	<path fill="#24b42e" d="m20 12l-8-8v4H4v8h8v4zM6 14v-4h8V8.83L17.17 12L14 15.17V14z" />
+	<text fill="#24b42e" x="8" y="6" fill="#fff" font-size="3.2" font-family="Arial, sans-serif"
+		text-anchor="middle" dominant-baseline="middle">http</text>
 </svg>

--- a/http-forwarder-app/wwwroot/swagger-http.svg
+++ b/http-forwarder-app/wwwroot/swagger-http.svg
@@ -2,6 +2,6 @@
 	<path d="M0 0h24v24H0z" fill="none" />
 	<path fill="#24b42e" d="M14 14v1.17L17.17 12L14 8.83V10H6v4z" opacity=".3" />
 	<path fill="#24b42e" d="m20 12l-8-8v4H4v8h8v4zM6 14v-4h8V8.83L17.17 12L14 15.17V14z" />
-	<text fill="#24b42e" x="8" y="6" fill="#fff" font-size="3.2" font-family="Arial, sans-serif"
+	<text x="8" y="6" fill="#fff" font-size="3.2" font-family="Arial, sans-serif"
 		text-anchor="middle" dominant-baseline="middle">http</text>
 </svg>


### PR DESCRIPTION
## Summary
- add the HTTP arrow SVG asset
- serve static Swagger assets from wwwroot
- inject custom Swagger UI CSS to display the icon

## Verification
- Docker .NET SDK: `dotnet test http-forwarder.slnx`
- Docker release image build
- Live container smoke test for Swagger HTML, CSS, and SVG assets